### PR TITLE
Updated to support large byte arrays

### DIFF
--- a/container/remote/src/main/java/org/mobicents/slee/connector/remote/RemoteEventWrapper.java
+++ b/container/remote/src/main/java/org/mobicents/slee/connector/remote/RemoteEventWrapper.java
@@ -73,7 +73,7 @@ public class RemoteEventWrapper implements Externalizable {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see java.io.Externalizable#writeExternal(java.io.ObjectOutput)
 	 */
 	@Override
@@ -86,18 +86,19 @@ public class RemoteEventWrapper implements Externalizable {
 		// add id?
 		out.writeInt(this.serializedEvent.length);
 		out.write(this.serializedEvent);
+        out.flush();
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see java.io.Externalizable#readExternal(java.io.ObjectInput)
 	 */
 	@Override
 	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
 		int len = in.readInt();
 		this.serializedEvent = new byte[len];
-		in.read(serializedEvent);
+		in.readFully(serializedEvent);
 	}
 
 	@Override


### PR DESCRIPTION
Since read() does not guarantee to fill array without a while loop I've changed the code to use readFully() instead.

Added flush to write() to be sure all bytes were written.

Fix for issue https://github.com/RestComm/jain-slee/issues/6