### PR TITLE
Code quality fix - Primitives should not be boxed just for "String" conversion.

### DIFF
--- a/container/activities/src/main/java/org/mobicents/slee/container/management/jmx/ActivityManagementMBeanImpl.java
+++ b/container/activities/src/main/java/org/mobicents/slee/container/management/jmx/ActivityManagementMBeanImpl.java
@@ -339,14 +339,10 @@ public class ActivityManagementMBeanImpl extends MobicentsServiceMBeanSupport
 						// we
 						// should care. But Console is java script, and
 						// sometimes that can be pain, so lets ease it
-						o[SBB_ATTACHMENTS] = ((Object[]) o[SBB_ATTACHMENTS]).length
-						+ "";
-						o[NAMES_BOUND_TO] = ((Object[]) o[NAMES_BOUND_TO]).length
-						+ "";
-						o[TIMERS_ATTACHED] = ((Object[]) o[TIMERS_ATTACHED]).length
-						+ "";
-						o[DATA_PROPERTIES] = ((Object[]) o[DATA_PROPERTIES]).length
-						+ "";
+					    o[SBB_ATTACHMENTS] = Integer.toString(((Object[]) o[SBB_ATTACHMENTS]).length);
+						o[NAMES_BOUND_TO] = Integer.toString(((Object[]) o[NAMES_BOUND_TO]).length);
+						o[TIMERS_ATTACHED] = Integer.toString(((Object[]) o[TIMERS_ATTACHED]).length);
+						o[DATA_PROPERTIES] = Integer.toString(((Object[]) o[DATA_PROPERTIES]).length);
 					}
 
 					singleResult = o;

--- a/container/components/components/src/main/java/org/mobicents/slee/container/component/validator/ProfileSpecificationComponentValidator.java
+++ b/container/components/components/src/main/java/org/mobicents/slee/container/component/validator/ProfileSpecificationComponentValidator.java
@@ -496,7 +496,7 @@ public class ProfileSpecificationComponentValidator implements Validator {
                   + cmpFieldName, "10.6", errorBuffer);				  
 				}
 				
-				cmpFieldName = cmpFieldName.replaceFirst(c + "", Character.toLowerCase(c) + "");
+				cmpFieldName = cmpFieldName.replaceFirst(c + "", Character.toString(Character.toLowerCase(c)));
 
 				// XXX: this will fail even for duplicate delcarations of
 				// fields, but meesages might be missleading.
@@ -1854,8 +1854,8 @@ public class ProfileSpecificationComponentValidator implements Validator {
           continue;				  
 				}
 				
-				queryName = queryName.replaceFirst(queryName.charAt(0) + "",
-						Character.toLowerCase(queryName.charAt(0)) + "");
+				queryName = queryName.replaceFirst(Character.toString(queryName.charAt(0)),
+						Character.toString(Character.toLowerCase(queryName.charAt(0))));
 
 				if (!nameToQueryMap.containsKey(queryName)) {
 					passed = false;
@@ -2098,9 +2098,9 @@ public class ProfileSpecificationComponentValidator implements Validator {
 			case Compare:
 				// XXX: We know that attribute starts with lower case
 				attributeName = expression.getCompare().getAttributeName();
-				attributeName = attributeName.replaceFirst(""
-						+ attributeName.charAt(0), ""
-						+ Character.toUpperCase(attributeName.charAt(0)));
+				attributeName = attributeName.replaceFirst(
+						Character.toString(attributeName.charAt(0)),
+						Character.toString(Character.toUpperCase(attributeName.charAt(0))));
 				// now we have to validate CMP field and type
 				CompareDescriptor compare = expression.getCompare();
 				String op = compare.getOp();
@@ -2200,9 +2200,9 @@ public class ProfileSpecificationComponentValidator implements Validator {
 			case HasPrefix:
 				HasPrefixDescriptor mhp = expression.getHasPrefix();
 				attributeName = expression.getHasPrefix().getAttributeName();
-				attributeName = attributeName.replaceFirst(""
-						+ attributeName.charAt(0), ""
-						+ Character.toUpperCase(attributeName.charAt(0)));
+				attributeName = attributeName.replaceFirst(
+						Character.toString(attributeName.charAt(0)),
+						Character.toString(Character.toUpperCase(attributeName.charAt(0))));
 				try {
 					Method m = cmpInterfaceClass.getMethod("get"
 							+ attributeName, null);
@@ -2278,9 +2278,9 @@ public class ProfileSpecificationComponentValidator implements Validator {
 				LongestPrefixMatchDescriptor mlpm = expression.getLongestPrefixMatch();
 				attributeName = expression.getLongestPrefixMatch()
 						.getAttributeName();
-				attributeName = attributeName.replaceFirst(""
-						+ attributeName.charAt(0), ""
-						+ Character.toUpperCase(attributeName.charAt(0)));
+				attributeName = attributeName.replaceFirst(
+						Character.toString(attributeName.charAt(0)),
+						Character.toString(Character.toUpperCase(attributeName.charAt(0))));
 
 				try {
 					Method m = cmpInterfaceClass.getMethod("get"
@@ -2354,9 +2354,9 @@ public class ProfileSpecificationComponentValidator implements Validator {
 				break;
 			case RangeMatch:
 				attributeName = expression.getRangeMatch().getAttributeName();
-				attributeName = attributeName.replaceFirst(""
-						+ attributeName.charAt(0), ""
-						+ Character.toUpperCase(attributeName.charAt(0)));
+				attributeName = attributeName.replaceFirst(
+						Character.toString(attributeName.charAt(0)),
+						Character.toString(Character.toUpperCase(attributeName.charAt(0))));
 				RangeMatchDescriptor mrm = expression.getRangeMatch();
 				try {
 					Method m = cmpInterfaceClass.getMethod("get"


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131- Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.

Faisal Hameed
