### PR TITLE
Code quality fix - Redundant casts should not be used

### DIFF
--- a/container/activities/src/main/java/org/mobicents/slee/container/management/jmx/ActivityManagementMBeanImpl.java
+++ b/container/activities/src/main/java/org/mobicents/slee/container/management/jmx/ActivityManagementMBeanImpl.java
@@ -287,7 +287,7 @@ public class ActivityManagementMBeanImpl extends MobicentsServiceMBeanSupport
 					SbbID implSbbID = null;
 					for (SbbEntityID sbbEntityID : ac.getSbbAttachmentSet()) {
 						if (sbbEntityIdToSbbID.containsKey(sbbEntityID)) {
-							implSbbID = (SbbID) sbbEntityIdToSbbID.get(sbbEntityID);
+							implSbbID = sbbEntityIdToSbbID.get(sbbEntityID);
 						} else {
 							SbbEntity sbbe = sbbEntityFactory.getSbbEntity(sbbEntityID,false);
 							if (sbbe == null) {

--- a/container/common/src/main/java/org/mobicents/slee/runtime/facilities/TraceFacilityImpl.java
+++ b/container/common/src/main/java/org/mobicents/slee/runtime/facilities/TraceFacilityImpl.java
@@ -112,7 +112,7 @@ public class TraceFacilityImpl implements TraceFacility {
 	}
 
 	public void setTraceLevelOnTransaction(final ComponentID componentId, Level newLevel) throws SystemException {
-		MTraceLevel traceLevel = (MTraceLevel) this.traceLevelTable.get(componentId);
+		MTraceLevel traceLevel = this.traceLevelTable.get(componentId);
 		final Level oldLevel = traceLevel == null ? null : traceLevel.level;
 		if (traceLevel == null) {
 			this.traceLevelTable.put(componentId, new MTraceLevel(newLevel));
@@ -126,7 +126,7 @@ public class TraceFacilityImpl implements TraceFacility {
 				if (oldLevel == null) {
 					traceLevelTable.remove(componentId);
 				} else {
-					((MTraceLevel) traceLevelTable.get(componentId)).level = oldLevel;
+					traceLevelTable.get(componentId).level = oldLevel;
 				}
 			}
 		};
@@ -134,7 +134,7 @@ public class TraceFacilityImpl implements TraceFacility {
 	}
 
 	public void setTraceLevel(ComponentID componentId, Level newLevel) {
-		MTraceLevel traceLevel = (MTraceLevel) this.traceLevelTable.get(componentId);
+		MTraceLevel traceLevel = this.traceLevelTable.get(componentId);
 		if (traceLevel == null) {
 			this.traceLevelTable.put(componentId, new MTraceLevel(newLevel));
 		} else {
@@ -143,7 +143,7 @@ public class TraceFacilityImpl implements TraceFacility {
 	}
 
 	public void unSetTraceLevel(final ComponentID componentId) throws SystemException {
-		final MTraceLevel level = (MTraceLevel) traceLevelTable.remove(componentId);
+		final MTraceLevel level = traceLevelTable.remove(componentId);
 		if (level != null) {
 			// since we are in a tx and this information is not tx aware ad
 			// rollback action
@@ -169,7 +169,7 @@ public class TraceFacilityImpl implements TraceFacility {
 	 */
 	public Level getTraceLevel(ComponentID componentId) throws NullPointerException, UnrecognizedComponentException, FacilityException {
 		checkComponentID(componentId);
-		return ((MTraceLevel) this.traceLevelTable.get(componentId)).getLevel();
+		return this.traceLevelTable.get(componentId).getLevel();
 	}
 
 	/*
@@ -185,7 +185,7 @@ public class TraceFacilityImpl implements TraceFacility {
 			log.debug("createTrace: " + componentId + " level = " + level + " messageType " + messageType + " message " + message + " timeStamp " + timeStamp);
 		}
 		checkComponentID(componentId);
-		MTraceLevel tl = (MTraceLevel) this.traceLevelTable.get(componentId);
+		MTraceLevel tl = this.traceLevelTable.get(componentId);
 		this.notificationTypes.add(messageType);
 		if (tl == null)
 			throw new UnrecognizedComponentException("Could not find " + componentId);
@@ -216,7 +216,7 @@ public class TraceFacilityImpl implements TraceFacility {
 			UnrecognizedComponentException, FacilityException {
 		checkComponentID(componentId);
 
-		MTraceLevel tl = (MTraceLevel) this.traceLevelTable.get(componentId);
+		MTraceLevel tl = this.traceLevelTable.get(componentId);
 		if (log.isDebugEnabled()) {
 			log.debug(" createTrace: " + componentId + " level " + level + " messageType " + messageType + " message " + message + " cause " + cause + " time stamp " + timeStamp);
 		}

--- a/container/components/components/src/main/java/org/mobicents/slee/container/component/security/PolicyFileImpl.java
+++ b/container/components/components/src/main/java/org/mobicents/slee/container/component/security/PolicyFileImpl.java
@@ -276,7 +276,7 @@ public class PolicyFileImpl extends org.mobicents.slee.container.component.secur
 		Map<ProtectionDomain, PermissionCollection> pdMap = this.currentPolicy.get().getProtectionDomain2PermissionCollection();
 		
 
-		PermissionCollection pc = (PermissionCollection) pdMap.get(domain);
+		PermissionCollection pc = pdMap.get(domain);
 
 		if (pc != null) {
 			return pc.implies(permission);

--- a/container/router/src/main/java/org/mobicents/slee/runtime/eventrouter/routingtask/InitialEventProcessor.java
+++ b/container/router/src/main/java/org/mobicents/slee/runtime/eventrouter/routingtask/InitialEventProcessor.java
@@ -89,7 +89,7 @@ public class InitialEventProcessor {
 			InitialEventSelectorImpl selector = new InitialEventSelectorImpl(eventContext,eventEntryDescriptor);
 			SbbObjectPool pool = sleeContainer.getSbbManagement().getObjectPool(serviceComponent.getServiceID(),
 					sbbComponent.getSbbID());
-			SbbObject sbbObject = (SbbObject) pool.borrowObject();
+			SbbObject sbbObject = pool.borrowObject();
 			Object[] args = new Object[] { selector };
 			ClassLoader oldCl = Thread.currentThread().getContextClassLoader();
 			try {

--- a/container/services/src/main/java/org/mobicents/slee/container/management/ServiceManagementImpl.java
+++ b/container/services/src/main/java/org/mobicents/slee/container/management/ServiceManagementImpl.java
@@ -747,8 +747,7 @@ public class ServiceManagementImpl extends AbstractSleeContainerModule
 					+ serviceComponent.getServiceID());
 		}
 
-		ServiceUsageMBean serviceUsageMBean = (ServiceUsageMBean) serviceComponent
-				.getServiceUsageMBean();
+		ServiceUsageMBean serviceUsageMBean = serviceComponent.getServiceUsageMBean();
 		if (serviceUsageMBean != null) {
 			serviceUsageMBean.remove();
 			// add rollback action to re-create the mbean

--- a/container/services/src/main/java/org/mobicents/slee/runtime/sbbentity/SbbEntityImpl.java
+++ b/container/services/src/main/java/org/mobicents/slee/runtime/sbbentity/SbbEntityImpl.java
@@ -745,7 +745,7 @@ public class SbbEntityImpl implements SbbEntity {
 		
 		try {
 			// get one object from the pool
-			this.sbbObject = (SbbObject) getObjectPool().borrowObject();
+			this.sbbObject = getObjectPool().borrowObject();
 			// invoke the appropriate sbb life-cycle methods
 			this.sbbObject.setSbbEntity(this);
 			if (created) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1905 - Redundant casts should not be used
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1905

Please let me know if you have any questions.

Faisal Hameed
