### PR TITLE
Code quality fix - Collections.emptyList(), emptyMap() and emptySet() should be used

### DIFF
--- a/container/activities/src/main/java/org/mobicents/slee/runtime/activity/ActivityContextCacheData.java
+++ b/container/activities/src/main/java/org/mobicents/slee/runtime/activity/ActivityContextCacheData.java
@@ -293,7 +293,7 @@ public class ActivityContextCacheData extends CacheData {
 	 */
 	public Set getAttachedTimers() {
 		final Node node = getAttachedTimersNode(false);
-		return node != null ? node.getChildrenNames() : Collections.EMPTY_SET;								
+		return node != null ? node.getChildrenNames() : Collections.emptySet();								
 	}
 
 	/**
@@ -335,7 +335,7 @@ public class ActivityContextCacheData extends CacheData {
 	 */
 	public Set getNamesBoundCopy() {
 		final Node node = getNamesBoundNode(false);
-		return node != null ? node.getChildrenNames() : Collections.EMPTY_SET;
+		return node != null ? node.getChildrenNames() : Collections.emptySet();
 	}
 
 	/**
@@ -386,7 +386,7 @@ public class ActivityContextCacheData extends CacheData {
 	public Map getCmpAttributesCopy() {
 		final Node node = getCmpAttributesNode(false);
 		if(node == null) {
-			return Collections.EMPTY_MAP;
+			return Collections.emptyMap();
 		}
 		else {
 			Map result = new HashMap();

--- a/container/activities/src/main/java/org/mobicents/slee/runtime/activity/ActivityContextFactoryCacheData.java
+++ b/container/activities/src/main/java/org/mobicents/slee/runtime/activity/ActivityContextFactoryCacheData.java
@@ -63,7 +63,7 @@ public class ActivityContextFactoryCacheData extends CacheData {
 	@SuppressWarnings("unchecked")
 	public Set<ActivityContextHandle> getActivityContextHandles() {
 		final Node node = getNode();
-		return node != null ? node.getChildrenNames() : Collections.EMPTY_SET;
+		return node != null ? node.getChildrenNames() : Collections.emptySet();
 	}
 
 }

--- a/container/common/src/main/java/org/mobicents/slee/container/deployment/ClassUtils.java
+++ b/container/common/src/main/java/org/mobicents/slee/container/deployment/ClassUtils.java
@@ -414,7 +414,7 @@ public class ClassUtils {
      * @return all interface methods from an interface
      */
     public static Map getInterfaceMethodsFromInterface(CtClass interfaceClass) {
-    	return getInterfaceMethodsFromInterface(interfaceClass, Collections.EMPTY_MAP);
+    	return getInterfaceMethodsFromInterface(interfaceClass, Collections.emptyMap());
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1596
Please let me know if you have any questions

Faisal Hameed
