### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/container/common/src/main/java/org/mobicents/slee/container/deployment/ClassUtils.java
+++ b/container/common/src/main/java/org/mobicents/slee/container/deployment/ClassUtils.java
@@ -508,7 +508,7 @@ public class ClassUtils {
         
 	        // this is not a precise check. Protected access for parent and Default for child will fail it.
 	        if (!(Modifier.isPublic(parent.getModifiers()) && Modifier.isPublic(child.getModifiers()))) return false;
-	        if ((!Modifier.isPrivate(parent.getModifiers()) && Modifier.isPrivate(child.getModifiers()))) return false;
+	        if (!Modifier.isPrivate(parent.getModifiers()) && Modifier.isPrivate(child.getModifiers())) return false;
 	
 	        // verify exceptions
 	        CtClass[] parentEx = parent.getExceptionTypes();
@@ -517,7 +517,7 @@ public class ClassUtils {
 		        for (int i = 0; i < parentEx.length; i++) {
 		            boolean validEx = false;
 		            for (int j = 0; j < childEx.length; j++) {
-		                if ((childEx[j]).subtypeOf((parentEx[i]))) validEx = true;
+		                if ((childEx[j]).subtypeOf(parentEx[i])) validEx = true;
 		            }
 		            if (!validEx) return false;
 		        }

--- a/container/common/src/main/java/org/mobicents/slee/container/deployment/jboss/DeployableUnit.java
+++ b/container/common/src/main/java/org/mobicents/slee/container/deployment/jboss/DeployableUnit.java
@@ -302,7 +302,7 @@ public class DeployableUnit {
    */
   public boolean isReadyToUninstall() throws Exception {
     // Check DU for readiness ..
-    return (isInstalled && !hasReferringDU());
+    return isInstalled && !hasReferringDU();
   }
 
   /**

--- a/container/common/src/main/java/org/mobicents/slee/container/deployment/jboss/DeploymentManager.java
+++ b/container/common/src/main/java/org/mobicents/slee/container/deployment/jboss/DeploymentManager.java
@@ -366,7 +366,7 @@ public class DeploymentManager {
           logger.error("Failure invoking '" + action, e);
         }
         else {
-          throw (e);
+          throw e;
         }
       }
 

--- a/container/common/src/main/java/org/mobicents/slee/runtime/facilities/NotificationSourceWrapperImpl.java
+++ b/container/common/src/main/java/org/mobicents/slee/runtime/facilities/NotificationSourceWrapperImpl.java
@@ -61,7 +61,7 @@ public class NotificationSourceWrapperImpl implements NotificationSourceWrapper,
 	
 	@Override
 	public int hashCode() {
-		return ((notificationSource == null) ? 0 : notificationSource.hashCode());		
+		return (notificationSource == null) ? 0 : notificationSource.hashCode();		
 	}
 	
 	@Override

--- a/container/resource/src/main/java/org/mobicents/slee/resource/ResourceAdaptorObjectImpl.java
+++ b/container/resource/src/main/java/org/mobicents/slee/resource/ResourceAdaptorObjectImpl.java
@@ -607,7 +607,7 @@ public class ResourceAdaptorObjectImpl implements ResourceAdaptorObject {
 	}
 
 	public boolean isFaultTolerant() {
-		return (this.object instanceof FaultTolerantResourceAdaptor);
+		return this.object instanceof FaultTolerantResourceAdaptor;
 	}
 
 	public ResourceAdaptor getResourceAdaptorObject() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed
