### PR TITLE
Code quality fix - "toString()" should never be called on a String object.

### DIFF
--- a/container/components/components/src/main/java/org/mobicents/slee/container/component/validator/UsageInterfaceValidator.java
+++ b/container/components/components/src/main/java/org/mobicents/slee/container/component/validator/UsageInterfaceValidator.java
@@ -372,7 +372,7 @@ public class UsageInterfaceValidator {
 			}
 		} finally {
 			if (!passed) {
-				logger.error(errorBuffer.toString());
+				logger.error(errorBuffer);
 				// System.err.println(errorBuffer);
 			}
 		}
@@ -447,7 +447,7 @@ public class UsageInterfaceValidator {
 
 		} finally {
 			if (!passed) {
-				logger.error(errorBuffer.toString());
+				logger.error(errorBuffer);
 				// ////System.err.println(errorBuffer);
 			}
 		}
@@ -489,7 +489,7 @@ public class UsageInterfaceValidator {
 
 		} finally {
 			if (!passed) {
-				logger.error(errorBuffer.toString());
+				logger.error(errorBuffer);
 				// ////System.err.println(errorBuffer);
 			}
 		}
@@ -544,7 +544,7 @@ public class UsageInterfaceValidator {
 		}
 
 		if (!passed) {
-			logger.error(errorBuffer.toString());
+			logger.error(errorBuffer);
 			// System.err.println(errorBuffer);
 		}
 
@@ -594,7 +594,7 @@ public class UsageInterfaceValidator {
 			errorBuffer = appendToBuffer(id, "Usage interface access method has wrong return type defined, method: " + m.getName(), section, errorBuffer);
 		}
 		if (!passed) {
-			logger.error(errorBuffer.toString());
+			logger.error(errorBuffer);
 			// System.err.println(errorBuffer);
 		}
 
@@ -662,7 +662,7 @@ public class UsageInterfaceValidator {
 		}
 
 		if (!passed) {
-			logger.error(errorBuffer.toString());
+			logger.error(errorBuffer);
 			// System.err.println(errorBuffer);
 		}
 

--- a/container/jmx-property-editors/src/main/java/org/mobicents/slee/container/management/jmx/editors/TraceLevelPropertyEditor.java
+++ b/container/jmx-property-editors/src/main/java/org/mobicents/slee/container/management/jmx/editors/TraceLevelPropertyEditor.java
@@ -54,7 +54,7 @@ public class TraceLevelPropertyEditor extends TextPropertyEditorSupport {
         if(level.equalsIgnoreCase(TraceLevel.SEVERE.toString()))
             super.setValue(TraceLevel.SEVERE);
         else
-            if(level.equalsIgnoreCase(TraceLevel.CONFIG_STRING.toString()))
+            if(level.equalsIgnoreCase(TraceLevel.CONFIG_STRING))
                 super.setValue(TraceLevel.CONFIG);
         else
             throw new IllegalArgumentException(" Bad level " + level);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1858 -  "toString()" should never be called on a String object.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1858

Please let me know if you have any questions.

Faisal Hameed
