### PR TITLE
Build: allow for newer Maven windows versions.

### DIFF
--- a/container/docs/sources-asciidoc/src/main/asciidoc/Common_Content/Setting_the_JBOSS_HOME_Environment_Variable.adoc
+++ b/container/docs/sources-asciidoc/src/main/asciidoc/Common_Content/Setting_the_JBOSS_HOME_Environment_Variable.adoc
@@ -5,8 +5,8 @@
 [[_jboss_home_setup]]
 = Setting the JBOSS_HOME Environment Variable
 
-The [app]` Platform` ([app]``) is built on top of the [app]``.
-You do not need to set the [var]`JBOSS_HOME` environment variable to run any of the [app]` Platform` servers _unless_ [var]`JBOSS_HOME` is _already_ set. 
+The [app]`{this-platform} Platform` ([app]`{this-platform}`) is built on top of [app]`{jee-platform}`.
+You do not need to set the [var]`JBOSS_HOME` environment variable to run any of the [app]`{this-platform} Platform` servers _unless_ [var]`JBOSS_HOME` is _already_ set. 
 
 The best way to know for sure whether [var]`JBOSS_HOME` was set previously or not is to perform a simple check which may save you time and frustration.
 
@@ -14,13 +14,13 @@ The best way to know for sure whether [var]`JBOSS_HOME` was set previously or no
 At the command line, `echo`			`$JBOSS_HOME` to see if it is currently defined in your environment:
 
 ----
-~]$ echo $JBOSS_HOME
+$ echo $JBOSS_HOME
 ----
 
-The [app]` Platform` and most &THIS.PLATFORM; servers are built on top of the [app]`` ([app]``). When the [app]` Platform` or &THIS.PLATFORM; servers are built _from source_, then [var]`JBOSS_HOME` _must_ be set, because the &THIS.PLATFORM; files are installed into (or "`over top of`" if you prefer) a clean [app]`` installation, and the build process assumes that the location pointed to by the [var]`JBOSS_HOME` environment variable at the time of building is the [app]`` installation into which you want it to install the &THIS.PLATFORM; files. 
+The [app]`{this-platform} Platform` and most {this-platform} servers are built on top of [app]`{jee-platform}` ([app]`{jee-platform}`). When the [app]`{this-platform} Platform` or {this-platform}  servers are built _from source_, then [var]`JBOSS_HOME` _must_ be set, because the {this-platform} files are installed into (or "`on top of`" if you prefer) a clean [app]`{jee-platform}` installation, and the build process assumes that the location pointed to by the [var]`JBOSS_HOME` environment variable at the time of building is the [app]`{jee-platform}` installation into which you want to install the {this-platform} files. 
 
-This guide does not detail building the [app]` Platform` or any &THIS.PLATFORM; servers from source.
-It is nevertheless useful to understand the role played by [app]`JBoss AS` and [var]`JBOSS_HOME` in the &THIS.PLATFORM; ecosystem.
+This guide does not detail building the [app]`{this-platform} Platform` or any {this-platform} servers from source.
+It is nevertheless useful to understand the role played by [app]`JBoss AS` and [var]`JBOSS_HOME` in the {this-platform} ecosystem.
 
 The immediately-following section considers whether you need to set [var]`JBOSS_HOME` at all and, if so, when.
 The subsequent sections detail how to set [var]`JBOSS_HOME` on Unix and Windows 
@@ -31,18 +31,18 @@ This can save you both time and frustration.
 
 You _DO NOT NEED_ to set [var]`JBOSS_HOME` if...
 
-* ...you have installed the [app]` Platform` binary distribution. 
-* ...you have installed a &THIS.PLATFORM;server binary distribution _which bundles [app]``._			
+* ...you have installed the [app]`{this-platform} Platform` binary distribution. 
+* ...you have installed a {this-platform} server binary distribution _which bundles [app]`{jee-platform}`._			
 
 You _MUST_ set [var]`JBOSS_HOME` if...
 
-* ...you are installing the [app]` Platform` or any of the &THIS.PLATFORM; servers _from source_. 
-* ...you are installing the [app]` Platform` binary distribution, or one of the &THIS.PLATFORM; server binary distributions, which _do not_ bundle [app]``. 
+* ...you are installing the [app]`{this-platform} Platform` or any of the {this-platform} servers _from source_. 
+* ...you are installing the [app]`{this-platform} Platform` binary distribution, or one of the {this-platform} server binary distributions, which _do not_ bundle [app]`{jee-platform}`. 
 
-Naturally, if you installed the [app]` Platform` or one of the &THIS.PLATFORM; server binary releases which _do not_ bundle [app]``, yet requires it to run, then you should install before setting [var]`JBOSS_HOME` or proceeding with anything else. 
+Naturally, if you installed the [app]`{this-platform} Platform` or one of the {this-platform} server binary releases which _do not_ bundle [app]`{jee-platform}`, yet requires it to run, then you should install before setting [var]`JBOSS_HOME` or proceeding with anything else. 
 
 .Setting the JBOSS_HOME Environment Variable on Unix
-The [var]`JBOSS_HOME` environment variable must point to the directory which contains all of the files for the [app]` Platform` or individual &THIS.PLATFORM; server that you installed.
+The [var]`JBOSS_HOME` environment variable must point to the directory which contains all of the files for the [app]`{this-platform} Platform` or individual {this-platform} server that you installed.
 As another hint, this topmost directory contains a [path]_bin_ subdirectory. 
 
 Setting [var]`JBOSS_HOME` in your personal [path]_~/.bashrc_ startup script carries the advantage of retaining effect over reboots.
@@ -53,7 +53,7 @@ On Unix, it is possible to set [var]`JBOSS_HOME` as a system-wide environment va
 . Open the [path]_~/.bashrc_ startup script, which is a hidden file in your home directory, in a text editor, and insert the following line on its own line while substituting for the actual install location on your system: 
 +
 ----
-export JBOSS_HOME="/home/<username>/<path>/<to>/<install_directory>"
+$ export JBOSS_HOME="/home/<username>/<path>/<to>/<install_directory>"
 ----
 
 . Save and close the [path]_.bashrc_ startup script. 
@@ -61,23 +61,23 @@ export JBOSS_HOME="/home/<username>/<path>/<to>/<install_directory>"
   ~/.bashrc as well should they require access to JBOSS_HOME.]. 
 +
 ----
-~]$ source ~/.bashrc
+$ source ~/.bashrc
 ----
 
 . Finally, ensure that [var]`JBOSS_HOME` is set in the current session, and actually points to the correct location: 
 +
-NOTE: The command line usage below is based upon a binary installation of the [app]` Platform`.
-In this sample output, [var]`JBOSS_HOME` has been set correctly to the [replaceable]`topmost_directory` of the [app]`` installation.
-Note that if you are installing one of the standalone [app]`` servers (with [app]`JBoss AS` bundled!), then [var]`JBOSS_HOME` would point to the [replaceable]`topmost_directory` of your server installation. 
+NOTE: The command line usage below is based upon a binary installation of the [app]`{this-platform} Platform`.
+In this sample output, [var]`JBOSS_HOME` has been set correctly to the [replaceable]`topmost_directory` of the [app]`{this-platform}` installation.
+Note that if you are installing one of the standalone [app]`{this-platform}` servers (with [app]`JBoss AS` bundled!), then [var]`JBOSS_HOME` would point to the [replaceable]`topmost_directory` of your server installation. 
 +
 ----
-~]$ echo $JBOSS_HOME
+$ echo $JBOSS_HOME
 /home/silas/<path>/<to>/<install_directory>
 ----
 
 
 .Setting the JBOSS_HOME Environment Variable on Windows
-The [var]`JBOSS_HOME` environment variable must point to the directory which contains all of the files for the &THIS.PLATFORM;Platform or individual &THIS.PLATFORM;server that you installed.
+The [var]`JBOSS_HOME` environment variable must point to the directory which contains all of the files for the {this-platform} Platform or individual {this-platform} server that you installed.
 As another hint, this topmost directory contains a [path]_bin_ subdirectory. 
 
 For information on how to set environment variables in recent versions of Windows, refer to http://support.microsoft.com/kb/931715. 

--- a/container/docs/sources-asciidoc/src/main/asciidoc/Common_Content/Setting_the_JBOSS_HOME_Environment_Variable.adoc
+++ b/container/docs/sources-asciidoc/src/main/asciidoc/Common_Content/Setting_the_JBOSS_HOME_Environment_Variable.adoc
@@ -5,8 +5,8 @@
 [[_jboss_home_setup]]
 = Setting the JBOSS_HOME Environment Variable
 
-The [app]`{this-platform} Platform` ([app]`{this-platform}`) is built on top of [app]`{jee-platform}`.
-You do not need to set the [var]`JBOSS_HOME` environment variable to run any of the [app]`{this-platform} Platform` servers _unless_ [var]`JBOSS_HOME` is _already_ set. 
+The [app]` Platform` ([app]``) is built on top of the [app]``.
+You do not need to set the [var]`JBOSS_HOME` environment variable to run any of the [app]` Platform` servers _unless_ [var]`JBOSS_HOME` is _already_ set. 
 
 The best way to know for sure whether [var]`JBOSS_HOME` was set previously or not is to perform a simple check which may save you time and frustration.
 
@@ -14,13 +14,13 @@ The best way to know for sure whether [var]`JBOSS_HOME` was set previously or no
 At the command line, `echo`			`$JBOSS_HOME` to see if it is currently defined in your environment:
 
 ----
-$ echo $JBOSS_HOME
+~]$ echo $JBOSS_HOME
 ----
 
-The [app]`{this-platform} Platform` and most {this-platform} servers are built on top of [app]`{jee-platform}` ([app]`{jee-platform}`). When the [app]`{this-platform} Platform` or {this-platform}  servers are built _from source_, then [var]`JBOSS_HOME` _must_ be set, because the {this-platform} files are installed into (or "`on top of`" if you prefer) a clean [app]`{jee-platform}` installation, and the build process assumes that the location pointed to by the [var]`JBOSS_HOME` environment variable at the time of building is the [app]`{jee-platform}` installation into which you want to install the {this-platform} files. 
+The [app]` Platform` and most &THIS.PLATFORM; servers are built on top of the [app]`` ([app]``). When the [app]` Platform` or &THIS.PLATFORM; servers are built _from source_, then [var]`JBOSS_HOME` _must_ be set, because the &THIS.PLATFORM; files are installed into (or "`over top of`" if you prefer) a clean [app]`` installation, and the build process assumes that the location pointed to by the [var]`JBOSS_HOME` environment variable at the time of building is the [app]`` installation into which you want it to install the &THIS.PLATFORM; files. 
 
-This guide does not detail building the [app]`{this-platform} Platform` or any {this-platform} servers from source.
-It is nevertheless useful to understand the role played by [app]`JBoss AS` and [var]`JBOSS_HOME` in the {this-platform} ecosystem.
+This guide does not detail building the [app]` Platform` or any &THIS.PLATFORM; servers from source.
+It is nevertheless useful to understand the role played by [app]`JBoss AS` and [var]`JBOSS_HOME` in the &THIS.PLATFORM; ecosystem.
 
 The immediately-following section considers whether you need to set [var]`JBOSS_HOME` at all and, if so, when.
 The subsequent sections detail how to set [var]`JBOSS_HOME` on Unix and Windows 
@@ -31,18 +31,18 @@ This can save you both time and frustration.
 
 You _DO NOT NEED_ to set [var]`JBOSS_HOME` if...
 
-* ...you have installed the [app]`{this-platform} Platform` binary distribution. 
-* ...you have installed a {this-platform} server binary distribution _which bundles [app]`{jee-platform}`._			
+* ...you have installed the [app]` Platform` binary distribution. 
+* ...you have installed a &THIS.PLATFORM;server binary distribution _which bundles [app]``._			
 
 You _MUST_ set [var]`JBOSS_HOME` if...
 
-* ...you are installing the [app]`{this-platform} Platform` or any of the {this-platform} servers _from source_. 
-* ...you are installing the [app]`{this-platform} Platform` binary distribution, or one of the {this-platform} server binary distributions, which _do not_ bundle [app]`{jee-platform}`. 
+* ...you are installing the [app]` Platform` or any of the &THIS.PLATFORM; servers _from source_. 
+* ...you are installing the [app]` Platform` binary distribution, or one of the &THIS.PLATFORM; server binary distributions, which _do not_ bundle [app]``. 
 
-Naturally, if you installed the [app]`{this-platform} Platform` or one of the {this-platform} server binary releases which _do not_ bundle [app]`{jee-platform}`, yet requires it to run, then you should install before setting [var]`JBOSS_HOME` or proceeding with anything else. 
+Naturally, if you installed the [app]` Platform` or one of the &THIS.PLATFORM; server binary releases which _do not_ bundle [app]``, yet requires it to run, then you should install before setting [var]`JBOSS_HOME` or proceeding with anything else. 
 
 .Setting the JBOSS_HOME Environment Variable on Unix
-The [var]`JBOSS_HOME` environment variable must point to the directory which contains all of the files for the [app]`{this-platform} Platform` or individual {this-platform} server that you installed.
+The [var]`JBOSS_HOME` environment variable must point to the directory which contains all of the files for the [app]` Platform` or individual &THIS.PLATFORM; server that you installed.
 As another hint, this topmost directory contains a [path]_bin_ subdirectory. 
 
 Setting [var]`JBOSS_HOME` in your personal [path]_~/.bashrc_ startup script carries the advantage of retaining effect over reboots.
@@ -53,7 +53,7 @@ On Unix, it is possible to set [var]`JBOSS_HOME` as a system-wide environment va
 . Open the [path]_~/.bashrc_ startup script, which is a hidden file in your home directory, in a text editor, and insert the following line on its own line while substituting for the actual install location on your system: 
 +
 ----
-$ export JBOSS_HOME="/home/<username>/<path>/<to>/<install_directory>"
+export JBOSS_HOME="/home/<username>/<path>/<to>/<install_directory>"
 ----
 
 . Save and close the [path]_.bashrc_ startup script. 
@@ -61,23 +61,23 @@ $ export JBOSS_HOME="/home/<username>/<path>/<to>/<install_directory>"
   ~/.bashrc as well should they require access to JBOSS_HOME.]. 
 +
 ----
-$ source ~/.bashrc
+~]$ source ~/.bashrc
 ----
 
 . Finally, ensure that [var]`JBOSS_HOME` is set in the current session, and actually points to the correct location: 
 +
-NOTE: The command line usage below is based upon a binary installation of the [app]`{this-platform} Platform`.
-In this sample output, [var]`JBOSS_HOME` has been set correctly to the [replaceable]`topmost_directory` of the [app]`{this-platform}` installation.
-Note that if you are installing one of the standalone [app]`{this-platform}` servers (with [app]`JBoss AS` bundled!), then [var]`JBOSS_HOME` would point to the [replaceable]`topmost_directory` of your server installation. 
+NOTE: The command line usage below is based upon a binary installation of the [app]` Platform`.
+In this sample output, [var]`JBOSS_HOME` has been set correctly to the [replaceable]`topmost_directory` of the [app]`` installation.
+Note that if you are installing one of the standalone [app]`` servers (with [app]`JBoss AS` bundled!), then [var]`JBOSS_HOME` would point to the [replaceable]`topmost_directory` of your server installation. 
 +
 ----
-$ echo $JBOSS_HOME
+~]$ echo $JBOSS_HOME
 /home/silas/<path>/<to>/<install_directory>
 ----
 
 
 .Setting the JBOSS_HOME Environment Variable on Windows
-The [var]`JBOSS_HOME` environment variable must point to the directory which contains all of the files for the {this-platform} Platform or individual {this-platform} server that you installed.
+The [var]`JBOSS_HOME` environment variable must point to the directory which contains all of the files for the &THIS.PLATFORM;Platform or individual &THIS.PLATFORM;server that you installed.
 As another hint, this topmost directory contains a [path]_bin_ subdirectory. 
 
 For information on how to set environment variables in recent versions of Windows, refer to http://support.microsoft.com/kb/931715. 

--- a/release/build.xml
+++ b/release/build.xml
@@ -66,6 +66,20 @@
 		<and>
 			<os family="windows" />
 			<isset property="sys.M2_HOME" />
+            <resourceexists>
+                <file file="${sys.M2_HOME}\bin\mvn.bat" />
+            </resourceexists>
+		</and>
+	</condition>
+
+    <!-- Newer Maven (-windows) versions shifted from .bat to .cmd. Accomodate that -->
+	<condition property="mvn.executable" value="${sys.M2_HOME}\bin\mvn.cmd">
+		<and>
+			<os family="windows" />
+			<isset property="sys.M2_HOME" />
+            <resourceexists>
+                <file file="${sys.M2_HOME}\bin\mvn.cmd" />
+            </resourceexists>
 		</and>
 	</condition>
 


### PR DESCRIPTION
`Maven` 3.5.0 for Windows only distributes with .cmd files now, no more .bat.
This change to the build accommodates that change.

Please review and commit.

Thanks,
Tom.