### PR TITLE
add profiles-management page

### DIFF
--- a/tools/slee-management-console/rpc/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileService.java
+++ b/tools/slee-management-console/rpc/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileService.java
@@ -1,0 +1,41 @@
+package org.mobicents.slee.container.management.console.client.profiles;
+
+import org.mobicents.slee.container.management.console.client.ManagementConsoleException;
+import org.mobicents.slee.container.management.console.client.PropertiesInfo;
+import org.mobicents.slee.container.management.console.client.components.info.ProfileSpecificationInfo;
+
+import com.google.gwt.user.client.rpc.RemoteService;
+
+public interface ProfileService extends RemoteService {
+
+	public void createProfileTable(String profileSpecId, String tableName) throws ManagementConsoleException;
+
+	public void createProfile(String tableName, String profileName) throws ManagementConsoleException;
+
+	public void createProfile(String tableName, String profileName, PropertiesInfo propertiesInfo)
+			throws ManagementConsoleException;
+
+	public String[] getProfileTables(String profileSpecificationId) throws ManagementConsoleException;
+
+	public String[] getProfiles(String tableName) throws ManagementConsoleException;
+
+	// public String[] getProfilesByIndexedAttribute(String arg0, String arg1,
+	// Object arg2)throws ManagementConsoleException;
+
+	public void removeProfile(String tableName, String profileName) throws ManagementConsoleException;
+
+	public void removeProfileTable(String tableName) throws ManagementConsoleException;
+
+	public void renameProfileTable(String currentTableName, String newTableName) throws ManagementConsoleException;
+
+
+	public String[] getProfileSpecifications() throws ManagementConsoleException;
+
+	public void restoreProfile(String tableName, String profileName) throws ManagementConsoleException;
+
+	public PropertiesInfo getProfileAttributes(String tableName, String profileName) throws ManagementConsoleException;
+
+	public void setProfileAttributes(String tableName, String profileName, PropertiesInfo propertiesInfo)
+			throws ManagementConsoleException;
+
+}

--- a/tools/slee-management-console/rpc/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileServiceAsync.java
+++ b/tools/slee-management-console/rpc/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileServiceAsync.java
@@ -1,0 +1,38 @@
+package org.mobicents.slee.container.management.console.client.profiles;
+
+import org.mobicents.slee.container.management.console.client.PropertiesInfo;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+public interface ProfileServiceAsync {
+
+	public void createProfileTable(String profileSpecId, String tableName, AsyncCallback callback);
+
+	public void createProfile(String tableName, String profileName, AsyncCallback callback);
+
+	public void createProfile(String tableName, String profileName, PropertiesInfo propertiesInfo,
+			AsyncCallback callback);
+
+	public void getProfileTables(String profileSpecificationId, AsyncCallback callback);
+
+	public void getProfiles(String tableName, AsyncCallback callback);
+
+	// public void getProfilesByIndexedAttribute(String arg0, String arg1,
+	// Object arg2, AsyncCallback callback);
+
+	public void removeProfile(String tableName, String profileName, AsyncCallback callback);
+
+	public void removeProfileTable(String tableName, AsyncCallback callback);
+
+	public void renameProfileTable(String currentTableName, String newTableName, AsyncCallback callback);
+
+	public void getProfileSpecifications(AsyncCallback callback);
+
+	public void restoreProfile(String tableName, String profileName, AsyncCallback callback);
+
+	public void getProfileAttributes(String tableName, String profileName, AsyncCallback callback);
+
+	public void setProfileAttributes(String tableName, String profileName, PropertiesInfo propertiesInfo,
+			AsyncCallback callback);
+
+}

--- a/tools/slee-management-console/rpc/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileTableInfo.java
+++ b/tools/slee-management-console/rpc/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileTableInfo.java
@@ -1,0 +1,47 @@
+package org.mobicents.slee.container.management.console.client.profiles;
+
+
+import com.google.gwt.user.client.rpc.IsSerializable;
+
+public class ProfileTableInfo implements IsSerializable{
+	private String tableName;
+	private String profileSpecName;
+	private String profileSpecVendor;
+	private String profileSpecVersion;
+	
+	public ProfileTableInfo() {
+		super();
+	}
+
+	public ProfileTableInfo(String tableName, String profileSpecName, String profileSpecVendor,
+			String profileSpecVersion) {
+		super();
+		this.tableName = tableName;
+		this.profileSpecName = profileSpecName;
+		this.profileSpecVendor = profileSpecVendor;
+		this.profileSpecVersion = profileSpecVersion;
+	}
+
+	public String getTableName() {
+		return tableName;
+	}
+
+	public String getProfileSpecName() {
+		return profileSpecName;
+	}
+
+	public String getProfileSpecVendor() {
+		return profileSpecVendor;
+	}
+
+	public String getProfileSpecVersion() {
+		return profileSpecVersion;
+	}
+
+	@Override
+	public String toString() {
+		return "ProfileTableInfo [tableName=" + tableName + ", profileSpecName=" + profileSpecName
+				+ ", profileSpecVendor=" + profileSpecVendor + ", profileSpecVersion=" + profileSpecVersion + "]";
+	}
+	
+}

--- a/tools/slee-management-console/server/src/main/java/org/mobicents/slee/container/management/console/server/mbeans/ProfileMBeanUtils.java
+++ b/tools/slee-management-console/server/src/main/java/org/mobicents/slee/container/management/console/server/mbeans/ProfileMBeanUtils.java
@@ -1,0 +1,605 @@
+package org.mobicents.slee.container.management.console.server.mbeans;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+
+import javax.management.Attribute;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanException;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.RuntimeMBeanException;
+import javax.slee.Address;
+import javax.slee.AddressPlan;
+
+import org.mobicents.slee.container.management.console.client.ManagementConsoleException;
+import org.mobicents.slee.container.management.console.server.Logger;
+import org.mobicents.slee.container.management.console.server.profiles.ProfileServiceImpl;
+
+public class ProfileMBeanUtils {
+	private MBeanServerConnection mbeanServer;
+
+	private ObjectName sleeManagementMBean;
+
+	private ProfileProvisioningMBeanUtils profileProvisioningMBeanUtils;
+
+
+
+	public ProfileMBeanUtils(MBeanServerConnection mbeanServer,
+			ProfileProvisioningMBeanUtils profileProvisioningMBeanUtils) throws ManagementConsoleException {
+		this.mbeanServer = mbeanServer;
+		this.profileProvisioningMBeanUtils = profileProvisioningMBeanUtils;
+	}
+
+	public void commitProfile(ObjectName profileMBean) throws ManagementConsoleException {
+		Exception ex = null;
+		try {
+			mbeanServer.invoke(profileMBean, "commitProfile", new Object[] {}, new String[] {});
+
+		} catch (Exception e) {
+			ex = e;
+			e.printStackTrace();
+		} finally {
+			close(profileMBean);
+			if (ex != null) {
+				throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(ex));
+			}
+		}
+	}
+
+	public void editProfile(ObjectName profileMBean) throws ManagementConsoleException {
+		try {
+			mbeanServer.invoke(profileMBean, "editProfile", new Object[] {}, new String[] {});
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
+
+	public void closeProfile(ObjectName profileMBean) throws ManagementConsoleException {
+		try {
+			mbeanServer.invoke(profileMBean, "closeProfile", new Object[] {}, new String[] {});
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
+
+	public void restoreProfile(ObjectName profileMBean) throws ManagementConsoleException {
+		try {
+			mbeanServer.invoke(profileMBean, "restoreProfile", new Object[] {}, new String[] {});
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
+
+	public void close(ObjectName profileMBean) throws ManagementConsoleException {
+		try {
+			mbeanServer.invoke(profileMBean, "close", new Object[] {}, new String[] {});
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
+
+	private MBeanAttributeInfo findAttribute(String attr_name, MBeanAttributeInfo[] attribute_info) {
+		for (int i = 0; i < attribute_info.length; i++) {
+			MBeanAttributeInfo mBeanAttributeInfo = attribute_info[i];
+			if (mBeanAttributeInfo.getName().equals(attr_name))
+				return mBeanAttributeInfo;
+		}
+		return null;
+	}
+
+	public void setAttribute(ObjectName profileMBean, Attribute attribute) throws ManagementConsoleException {
+		String type = null;
+		Class attributeClass;
+		try {
+			Attribute newAttribute = null;
+
+			MBeanAttributeInfo[] mBeanAttributeInfos = mbeanServer.getMBeanInfo(profileMBean).getAttributes();
+
+			MBeanAttributeInfo info = findAttribute(attribute.getName(), mBeanAttributeInfos);
+
+			type = info.getType();
+
+			if (attribute.getValue() == null) {
+				newAttribute = new Attribute(attribute.getName(), null);
+			} else if (type.equals("int")) {
+				int value = Integer.parseInt((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+
+			} else if (type.equals("short")) {
+				short value = Short.parseShort((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+			} else if (type.equals("long")) {
+				long value = Long.parseLong((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+			} else if (type.equals("float")) {
+				float value = Float.parseFloat((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+			} else if (type.equals("boolean")) {
+				boolean value = Boolean.parseBoolean((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+			} else if (type.equals("byte")) {
+				byte value = Byte.parseByte((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+
+			} else if (type.equals("double")) {
+				double value = Double.parseDouble((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+
+			} else {
+
+				attributeClass = Class.forName(type);
+				if (attributeClass.isArray()) {
+
+					Class arrayValuesClass = attributeClass.getComponentType();
+
+					String[] values = ((String) attribute.getValue()).split(ProfileServiceImpl.ARRAY_SEPARATOR);
+
+					Object array = Array.newInstance(arrayValuesClass, values.length);
+
+					for (int j = 0; j < values.length; j++) {
+
+						if (arrayValuesClass.isPrimitive()) {
+
+							String token = values[j];
+
+							String canonicalName = array.getClass().getComponentType().getCanonicalName();
+
+							if (canonicalName.equals("byte")) {
+								Array.set(array, j, Byte.parseByte(token));
+							} else if (canonicalName.equals("short")) {
+								Array.set(array, j, Short.parseShort(token));
+							} else if (canonicalName.equals("int")) {
+								Array.set(array, j, Integer.parseInt(token));
+							} else if (canonicalName.equals("long")) {
+								Array.set(array, j, Long.parseLong(token));
+							} else if (canonicalName.equals("float")) {
+								Array.set(array, j, Float.parseFloat(token));
+							} else if (canonicalName.equals("double")) {
+								Array.set(array, j, Double.parseDouble(token));
+							} else if (canonicalName.equals("boolean")) {
+								Array.set(array, j, Boolean.parseBoolean(token));
+							} else if (canonicalName.equals("char")) {
+								Array.set(array, j, token.charAt(0));
+							} else {
+								Logger.error("Did not find cast method for type: " + arrayValuesClass.getCanonicalName());
+							}
+
+						} else {
+							Object value = null;
+							if (arrayValuesClass.getName().equals("javax.slee.Address")) {
+								try {
+									int delimerSize = 2;
+									int delimiter = values[j].indexOf(": ");
+									if (delimiter == -1) {
+										delimerSize = 1;
+										delimiter = values[j].indexOf(":");
+									}
+									if (delimiter == -1) {
+										throw new IllegalArgumentException(
+												"\nAddress arg should be \"address plan as string\" + \": \" + \"address as string\"\n");
+									}
+									String addressPlan = values[j].substring(0, delimiter);
+									String address = values[j].substring(delimiter + delimerSize);
+									value = new Address(AddressPlan.fromString(addressPlan), address);
+								} catch (Exception ex) {
+									throw new IllegalArgumentException(ex.getMessage(), ex);
+								}
+							} else {
+								Constructor con = arrayValuesClass.getConstructor(String.class);
+								if (con != null) {
+									value = con.newInstance((String) values[j]);
+								}
+							}
+							Array.set(array, j, value);
+						}
+
+					}
+					newAttribute = new Attribute(attribute.getName(), array);
+
+				} else {
+					Object value = null;
+					if (attributeClass.getName().equals("javax.slee.Address")) {
+						try {
+
+							int delimerSize = 2;
+							int delimiter = ((String) attribute.getValue()).indexOf(": ");
+							if (delimiter == -1) {
+								delimerSize = 1;
+								delimiter = ((String) attribute.getValue()).indexOf(":");
+							}
+							if (delimiter == -1) {
+								throw new IllegalArgumentException(
+										"\nAddress arg should be \"address plan as string\" + \": \" + \"address as string\"\n");
+							}
+							String addressPlan = ((String) attribute.getValue()).substring(0, delimiter);
+							String address = ((String) attribute.getValue()).substring(delimiter + delimerSize);
+							value = new Address(AddressPlan.fromString(addressPlan), address);
+						} catch (Exception ex) {
+							throw new IllegalArgumentException(ex.getMessage(), ex);
+						}
+					} else {
+						Constructor con = attributeClass.getConstructor(String.class);
+						if (con != null) {
+							value = con.newInstance((String) attribute.getValue());
+						} else {
+							throw new ClassNotFoundException(
+									"can not find constructor for attribute " + attribute.getName());
+						}
+					}
+					newAttribute = new Attribute(attribute.getName(), value);
+
+				}
+
+			}
+
+			mbeanServer.setAttribute(profileMBean, newAttribute);
+		} catch (Exception e) {
+			Logger.error("closing Profile due to unvalid attribute value");
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+
+	}
+	public void setAttribute(ObjectName profileMBean, Attribute attribute,String type) throws ManagementConsoleException {
+		Class attributeClass;
+		try {
+			Attribute newAttribute = null;
+
+
+			if (attribute.getValue() == null) {
+				newAttribute = new Attribute(attribute.getName(), null);
+			} else if (type.equals("int")) {
+				int value = Integer.parseInt((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+
+			} else if (type.equals("short")) {
+				short value = Short.parseShort((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+			} else if (type.equals("long")) {
+				long value = Long.parseLong((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+			} else if (type.equals("float")) {
+				float value = Float.parseFloat((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+			} else if (type.equals("boolean")) {
+				boolean value = Boolean.parseBoolean((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+			} else if (type.equals("byte")) {
+				byte value = Byte.parseByte((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+
+			} else if (type.equals("double")) {
+				double value = Double.parseDouble((String) attribute.getValue());
+				newAttribute = new Attribute(attribute.getName(), value);
+
+			} else {
+
+				attributeClass = Class.forName(type);
+				if (attributeClass.isArray()) {
+
+					Class arrayValuesClass = attributeClass.getComponentType();
+
+					String[] values = ((String) attribute.getValue()).split(ProfileServiceImpl.ARRAY_SEPARATOR);
+
+					Object array = Array.newInstance(arrayValuesClass, values.length);
+
+					for (int j = 0; j < values.length; j++) {
+
+						if (arrayValuesClass.isPrimitive()) {
+
+							String token = values[j];
+
+							String canonicalName = array.getClass().getComponentType().getCanonicalName();
+
+							if (canonicalName.equals("byte")) {
+								Array.set(array, j, Byte.parseByte(token));
+							} else if (canonicalName.equals("short")) {
+								Array.set(array, j, Short.parseShort(token));
+							} else if (canonicalName.equals("int")) {
+								Array.set(array, j, Integer.parseInt(token));
+							} else if (canonicalName.equals("long")) {
+								Array.set(array, j, Long.parseLong(token));
+							} else if (canonicalName.equals("float")) {
+								Array.set(array, j, Float.parseFloat(token));
+							} else if (canonicalName.equals("double")) {
+								Array.set(array, j, Double.parseDouble(token));
+							} else if (canonicalName.equals("boolean")) {
+								Array.set(array, j, Boolean.parseBoolean(token));
+							} else if (canonicalName.equals("char")) {
+								Array.set(array, j, token.charAt(0));
+							} else {
+								Logger.error("Did not find cast method for type: " + arrayValuesClass.getCanonicalName());
+							}
+
+						} else {
+							Object value = null;
+							if (arrayValuesClass.getName().equals("javax.slee.Address")) {
+								try {
+									int delimerSize = 2;
+									int delimiter = values[j].indexOf(": ");
+									if (delimiter == -1) {
+										delimerSize = 1;
+										delimiter = values[j].indexOf(":");
+									}
+									if (delimiter == -1) {
+										throw new IllegalArgumentException(
+												"\nAddress arg should be \"address plan as string\" + \": \" + \"address as string\"\n");
+									}
+									String addressPlan = values[j].substring(0, delimiter);
+									String address = values[j].substring(delimiter + delimerSize);
+									value = new Address(AddressPlan.fromString(addressPlan), address);
+								} catch (Exception ex) {
+									throw new IllegalArgumentException(ex.getMessage(), ex);
+								}
+							} else {
+								Constructor con = arrayValuesClass.getConstructor(String.class);
+								if (con != null) {
+									value = con.newInstance((String) values[j]);
+								}
+							}
+							Array.set(array, j, value);
+						}
+
+					}
+					newAttribute = new Attribute(attribute.getName(), array);
+
+				} else {
+					Object value = null;
+					if (attributeClass.getName().equals("javax.slee.Address")) {
+						try {
+
+							int delimerSize = 2;
+							int delimiter = ((String) attribute.getValue()).indexOf(": ");
+							if (delimiter == -1) {
+								delimerSize = 1;
+								delimiter = ((String) attribute.getValue()).indexOf(":");
+							}
+							if (delimiter == -1) {
+								throw new IllegalArgumentException(
+										"\nAddress arg should be \"address plan as string\" + \": \" + \"address as string\"\n");
+							}
+							String addressPlan = ((String) attribute.getValue()).substring(0, delimiter);
+							String address = ((String) attribute.getValue()).substring(delimiter + delimerSize);
+							value = new Address(AddressPlan.fromString(addressPlan), address);
+						} catch (Exception ex) {
+							throw new IllegalArgumentException(ex.getMessage(), ex);
+						}
+					} else {
+						Constructor con = attributeClass.getConstructor(String.class);
+						if (con != null) {
+							value = con.newInstance((String) attribute.getValue());
+						} else {
+							throw new ClassNotFoundException(
+									"can not find constructor for attribute " + attribute.getName());
+						}
+					}
+					newAttribute = new Attribute(attribute.getName(), value);
+
+				}
+
+			}
+
+			mbeanServer.setAttribute(profileMBean, newAttribute);
+		} catch (Exception e) {
+			Logger.error("closing Profile due to unvalid attribute value");
+
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+
+	}
+	public String[] getAllAttributes(ObjectName profileMBean) throws ManagementConsoleException {
+		String[] attributesNames;
+		try {
+			MBeanAttributeInfo[] attributeInfos = mbeanServer.getMBeanInfo(profileMBean).getAttributes();
+			attributesNames = new String[attributeInfos.length];
+
+			for (int i = 0; i < attributeInfos.length; i++) {
+				attributesNames[i] = attributeInfos[i].getName() + ProfileServiceImpl.NAME_TYPE_SEPARATOR+ attributeInfos[i].getType();
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+		return attributesNames;
+	}
+
+	public String getAttribute(ObjectName profileMBean, String attributeName) throws ManagementConsoleException {
+		String attributeValue;
+		try {
+			attributeValue = (String) mbeanServer.getAttribute(profileMBean, attributeName);
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+		return attributeValue;
+	}
+
+	public String[] getAttributes(ObjectName profileMBean, String[] attributesNames) throws ManagementConsoleException {
+		String[] attributesValues = new String[attributesNames.length];
+
+		for (int i = 0; i < attributesNames.length; i++) {
+
+			Object objectvalue = null;
+
+			try {
+				objectvalue = mbeanServer.getAttribute(profileMBean, attributesNames[i]);
+			} catch (AttributeNotFoundException e) {
+				e.printStackTrace();
+				throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+			} catch (InstanceNotFoundException e) {
+				e.printStackTrace();
+				throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+			} catch (MBeanException e) {
+				e.printStackTrace();
+				throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+			} catch (ReflectionException e) {
+				e.printStackTrace();
+				throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+			} catch (IOException e) {
+				e.printStackTrace();
+				throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+			} catch (RuntimeMBeanException e) {
+				attributesValues[i] = null;
+				continue;
+			}
+
+			if (objectvalue != null) {
+				Class clazz = objectvalue.getClass();
+
+
+				if (clazz.equals(long[].class)) {
+
+					long[] values = (long[]) objectvalue;
+					if (values.length == 0) {
+						attributesValues[i] = null;
+						continue;
+					}
+
+					attributesValues[i] = "0";
+					for (int j = 0; j < values.length; j++) {
+						if (j == 0) {
+							attributesValues[i] = String.valueOf(values[j]);
+						} else {
+							attributesValues[i] = attributesValues[i] + "," + String.valueOf(values[j]);
+						}
+					}
+				} else if (clazz.equals(short[].class)) {
+					short[] values = (short[]) objectvalue;
+
+					if (values.length == 0) {
+						attributesValues[i] = null;
+						continue;
+					}
+
+					attributesValues[i] = "0";
+					for (int j = 0; j < values.length; j++) {
+						if (j == 0) {
+							attributesValues[i] = String.valueOf(values[j]);
+						} else {
+							attributesValues[i] = String.valueOf(values[j - 1]) + "," + String.valueOf(values[j]);
+						}
+					}
+
+				} else if (clazz.equals(int[].class)) {
+					int[] values = (int[]) objectvalue;
+					if (values.length == 0) {
+						attributesValues[i] = null;
+						continue;
+					}
+
+					attributesValues[i] = "0";
+					for (int j = 0; j < values.length; j++) {
+						if (j == 0) {
+							attributesValues[i] = String.valueOf(values[j]);
+						} else {
+							attributesValues[i] = attributesValues[i] + "," + String.valueOf(values[j]);
+						}
+					}
+				} else if (clazz.equals(double[].class)) {
+					double[] values = (double[]) objectvalue;
+					if (values.length == 0) {
+						attributesValues[i] = null;
+						continue;
+					}
+					attributesValues[i] = "0";
+					for (int j = 0; j < values.length; j++) {
+						if (j == 0) {
+							attributesValues[i] = String.valueOf(values[j]);
+						} else {
+							attributesValues[i] = attributesValues[i] + "," + String.valueOf(values[j]);
+						}
+					}
+				} else if (clazz.equals(float[].class)) {
+					float[] values = (float[]) objectvalue;
+					if (values.length == 0) {
+						attributesValues[i] = null;
+						continue;
+					}
+					attributesValues[i] = "0";
+					for (int j = 0; j < values.length; j++) {
+						if (j == 0) {
+							attributesValues[i] = String.valueOf(values[j]);
+						} else {
+							attributesValues[i] = attributesValues[i] + "," + String.valueOf(values[j]);
+						}
+					}
+				} else if (clazz.equals(byte[].class)) {
+					byte[] values = (byte[]) objectvalue;
+					if (values.length == 0) {
+						attributesValues[i] = null;
+						continue;
+					}
+					attributesValues[i] = "0";
+					for (int j = 0; j < values.length; j++) {
+						if (j == 0) {
+							attributesValues[i] = String.valueOf(values[j]);
+						} else {
+							attributesValues[i] = attributesValues[i] + "," + String.valueOf(values[j]);
+						}
+					}
+				} else if (clazz.equals(boolean[].class)) {
+					boolean[] values = (boolean[]) objectvalue;
+					if (values.length == 0) {
+						attributesValues[i] = null;
+						continue;
+					}
+					attributesValues[i] = "false";
+					for (int j = 0; j < values.length; j++) {
+						if (j == 0) {
+							attributesValues[i] = String.valueOf(values[j]);
+						} else {
+							attributesValues[i] = attributesValues[i] + "," + String.valueOf(values[j]);
+						}
+					}
+				} else if (clazz.equals(char[].class)) {
+					char[] values = (char[]) objectvalue;
+					if (values.length == 0) {
+						attributesValues[i] = null;
+						continue;
+					}
+					attributesValues[i] = " ";
+					for (int j = 0; j < values.length; j++) {
+						if (j == 0) {
+							attributesValues[i] = String.valueOf(values[j]);
+						} else {
+							attributesValues[i] = attributesValues[i] + "," + String.valueOf(values[j]);
+						}
+					}
+				} else if (clazz.equals(String[].class)) {
+					String[] values = (String[]) objectvalue;
+					if (values.length == 0) {
+						attributesValues[i] = null;
+						continue;
+					}
+					attributesValues[i] = "null";
+					for (int j = 0; j < values.length; j++) {
+						if (j == 0) {
+							attributesValues[i] = values[j];
+						} else {
+							attributesValues[i] = attributesValues[i] + "," + values[j];
+						}
+					}
+				} else {
+					attributesValues[i] = objectvalue.toString();
+
+				}
+			} else {
+				attributesValues[i] = null;
+			}
+		}
+
+		return attributesValues;
+	}
+
+
+}

--- a/tools/slee-management-console/server/src/main/java/org/mobicents/slee/container/management/console/server/mbeans/ProfileProvisioningMBeanUtils.java
+++ b/tools/slee-management-console/server/src/main/java/org/mobicents/slee/container/management/console/server/mbeans/ProfileProvisioningMBeanUtils.java
@@ -22,10 +22,14 @@
 
 package org.mobicents.slee.container.management.console.server.mbeans;
 
+import java.io.IOException;
 import java.util.Collection;
 
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.ReflectionException;
 import javax.slee.profile.ProfileSpecificationID;
 
 import org.mobicents.slee.container.management.console.client.ManagementConsoleException;
@@ -36,136 +40,217 @@ import org.mobicents.slee.container.management.console.client.ManagementConsoleE
  */
 public class ProfileProvisioningMBeanUtils {
 
-  private MBeanServerConnection mbeanServer;
+	private MBeanServerConnection mbeanServer;
 
-  private ObjectName profileProvisioningMBean;
+	private ObjectName profileProvisioningMBean;
 
-  public ProfileProvisioningMBeanUtils(MBeanServerConnection mbeanServer, ObjectName sleeManagementMBean) throws ManagementConsoleException {
-    super();
-    this.mbeanServer = mbeanServer;
+	public ProfileProvisioningMBeanUtils(MBeanServerConnection mbeanServer, ObjectName sleeManagementMBean)
+			throws ManagementConsoleException {
+		super();
+		this.mbeanServer = mbeanServer;
 
-    try {
-      profileProvisioningMBean = (ObjectName) mbeanServer.getAttribute(sleeManagementMBean, "ProfileProvisioningMBean");
-    }
-    catch (Exception e) {
-      e.printStackTrace();
-      throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
-    }
-  }
+		try {
+			profileProvisioningMBean = (ObjectName) mbeanServer.getAttribute(sleeManagementMBean,
+					"ProfileProvisioningMBean");
+//			profileProvisioningMBean = new ObjectName("javax.slee.management:name=ProfileProvisioning");
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#createProfile(java.lang.String, java.lang.String)
-   */
-  public ObjectName createProfile(String arg0, String arg1) throws ManagementConsoleException {
-    // TODO Auto-generated method stub
-    return null;
-  }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#createProfile(java.lang.
+	 * String, java.lang.String)
+	 */
+	public ObjectName createProfile(String arg0, String arg1) throws ManagementConsoleException {
+		try {
+			return (ObjectName) mbeanServer.invoke(profileProvisioningMBean, "createProfile",
+					new Object[] { arg0, arg1 }, new String[] { String.class.getName(), String.class.getName() });
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#createProfileTable(javax.slee.profile.ProfileSpecificationID, java.lang.String)
-   */
-  public void createProfileTable(ProfileSpecificationID arg0, String arg1) throws ManagementConsoleException {
-    // TODO Auto-generated method stub
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#createProfileTable(javax.
+	 * slee.profile.ProfileSpecificationID, java.lang.String)
+	 */
+	public void createProfileTable(ProfileSpecificationID arg0, String arg1) throws ManagementConsoleException {
+		try {
+			mbeanServer.invoke(profileProvisioningMBean, "createProfileTable", new Object[] { arg0, arg1 },
+					new String[] { ProfileSpecificationID.class.getName(), String.class.getName() });
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
 
-  }
+	}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#getDefaultProfile(java.lang.String)
-   */
-  public ObjectName getDefaultProfile(String arg0) throws ManagementConsoleException {
-    // TODO Auto-generated method stub
-    return null;
-  }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#getDefaultProfile(java.
+	 * lang.String)
+	 */
+	public ObjectName getDefaultProfile(String arg0) throws ManagementConsoleException {
+		try {
+			return (ObjectName) mbeanServer.invoke(profileProvisioningMBean, "getDefaultProfile", new Object[] { arg0 },
+					new String[] { String.class.getName() });
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#getProfile(java.lang.String, java.lang.String)
-   */
-  public ObjectName getProfile(String arg0, String arg1) throws ManagementConsoleException {
-    // TODO Auto-generated method stub
-    return null;
-  }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#getProfile(java.lang.
+	 * String, java.lang.String)
+	 */
+	public ObjectName getProfile(String arg0, String arg1) throws ManagementConsoleException {
+		try {
+			return (ObjectName) mbeanServer.invoke(profileProvisioningMBean, "getProfile", new Object[] { arg0, arg1 },
+					new String[] { String.class.getName(), String.class.getName() });
+		} catch (InstanceNotFoundException e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		} catch (MBeanException e) {
+			try {
+				return (ObjectName) mbeanServer.invoke(profileProvisioningMBean, "getProfile", new Object[] { arg0, arg1 },
+						new String[] { String.class.getName(), String.class.getName() });
+			} catch (Exception e1) {
+				e1.printStackTrace();
+				throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+			} 
+		} catch (ReflectionException e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		} catch (IOException e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#getProfileSpecification(java.lang.String)
-   */
-  public ProfileSpecificationID getProfileSpecification(String arg0) throws ManagementConsoleException {
-    // TODO Auto-generated method stub
-    return null;
-  }
+	}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#getProfileTables()
-   */
-  public Collection getProfileTables() throws ManagementConsoleException {
-    try {
-      return (Collection) mbeanServer.invoke(profileProvisioningMBean, "getProfileTables", new Object[] {}, new String[] {});
-    }
-    catch (Exception e) {
-      e.printStackTrace();
-      throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
-    }
-  }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#getProfileSpecification(
+	 * java.lang.String)
+	 */
+	public ProfileSpecificationID getProfileSpecification(String arg0) throws ManagementConsoleException {
+		try {
+			return (ProfileSpecificationID) mbeanServer.invoke(profileProvisioningMBean, "getProfileSpecification",
+					new Object[] { arg0 }, new String[] { String.class.getName() });
+		} catch (Exception e) {
+			return null;
+		}
+	}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#getProfiles(java.lang.String)
-   */
-  public Collection getProfiles(String arg0) throws ManagementConsoleException {
-    // TODO Auto-generated method stub
-    return null;
-  }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#getProfileTables()
+	 */
+	public Collection getProfileTables() throws ManagementConsoleException {
+		try {
+			return (Collection) mbeanServer.invoke(profileProvisioningMBean, "getProfileTables", new Object[] {},
+					new String[] {});
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#getProfilesByIndexedAttribute(java.lang.String, java.lang.String, java.lang.Object)
-   */
-  public Collection getProfilesByIndexedAttribute(String arg0, String arg1, Object arg2) throws ManagementConsoleException {
-    // TODO Auto-generated method stub
-    return null;
-  }
+	public Collection getProfileTables(ProfileSpecificationID profileSpecificationID)
+			throws ManagementConsoleException {
+		try {
+			return (Collection) mbeanServer.invoke(profileProvisioningMBean, "getProfileTables",
+					new Object[] { profileSpecificationID }, new String[] { ProfileSpecificationID.class.getName() });
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#removeProfile(java.lang.String, java.lang.String)
-   */
-  public void removeProfile(String arg0, String arg1) throws ManagementConsoleException {
-    // TODO Auto-generated method stub
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#getProfiles(java.lang.
+	 * String)
+	 */
+	public Collection getProfiles(String arg0) throws ManagementConsoleException {
+		try {
+			return (Collection) mbeanServer.invoke(profileProvisioningMBean, "getProfiles", new Object[] { arg0 },
+					new String[] { String.class.getName() });
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
 
-  }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#
+	 * getProfilesByIndexedAttribute(java.lang.String, java.lang.String,
+	 * java.lang.Object)
+	 */
+	public Collection getProfilesByIndexedAttribute(String arg0, String arg1, Object arg2)
+			throws ManagementConsoleException {
+		// TODO Auto-generated method stub
+		return null;
+	}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#removeProfileTable(java.lang.String)
-   */
-  public void removeProfileTable(String arg0) throws ManagementConsoleException {
-    // TODO Auto-generated method stub
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#removeProfile(java.lang.
+	 * String, java.lang.String)
+	 */
+	public void removeProfile(String arg0, String arg1) throws ManagementConsoleException {
+		try {
+			mbeanServer.invoke(profileProvisioningMBean, "removeProfile", new Object[] { arg0, arg1 },
+					new String[] { String.class.getName(), String.class.getName() });
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
 
-  }
+	}
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see javax.slee.management.ProfileProvisioningMBean#renameProfileTable(java.lang.String, java.lang.String)
-   */
-  public void renameProfileTable(String arg0, String arg1) throws ManagementConsoleException {
-    // TODO Auto-generated method stub
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#removeProfileTable(java.
+	 * lang.String)
+	 */
+	public void removeProfileTable(String arg0) throws ManagementConsoleException {
+		try {
+			mbeanServer.invoke(profileProvisioningMBean, "removeProfileTable", new Object[] { arg0 },
+					new String[] { String.class.getName() });
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new ManagementConsoleException(SleeManagementMBeanUtils.doMessage(e));
+		}
+	}
 
-  }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.slee.management.ProfileProvisioningMBean#renameProfileTable(java.
+	 * lang.String, java.lang.String)
+	 */
+	public void renameProfileTable(String arg0, String arg1) throws ManagementConsoleException {
+		// TODO Auto-generated method stub
+
+	}
 
 }

--- a/tools/slee-management-console/server/src/main/java/org/mobicents/slee/container/management/console/server/mbeans/SleeManagementMBeanUtils.java
+++ b/tools/slee-management-console/server/src/main/java/org/mobicents/slee/container/management/console/server/mbeans/SleeManagementMBeanUtils.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.slee.container.management.console.server.mbeans;
 
-import org.mobicents.slee.container.management.console.client.ManagementConsoleException;
-
 import javax.management.MBeanException;
 import javax.management.MBeanServerConnection;
 import javax.management.NotificationListener;
@@ -35,7 +33,7 @@ import javax.slee.management.SleeProvider;
 import javax.slee.management.SleeProviderFactory;
 import javax.slee.management.SleeState;
 
-import org.jboss.remotingjmx.Util;
+import org.mobicents.slee.container.management.console.client.ManagementConsoleException;
 
 
 /**
@@ -66,6 +64,8 @@ public class SleeManagementMBeanUtils {
   private LogManagementMBeanUtils logManagementMBeanUtils;
   
   private AlarmMBeanUtils alarmMBeanUtils;
+  
+  private ProfileMBeanUtils profileMBeanUtils;
 
   public SleeManagementMBeanUtils() throws ManagementConsoleException {
     try {
@@ -119,7 +119,9 @@ public class SleeManagementMBeanUtils {
     logManagementMBeanUtils = new LogManagementMBeanUtils(mbeanServer, sleeManagementMBean);
     
     alarmMBeanUtils = new AlarmMBeanUtils(mbeanServer, sleeManagementMBean);
-  }
+   
+    profileMBeanUtils = new ProfileMBeanUtils(mbeanServer, profileProvisioningMBeanUtils);  
+}
 
   public DeploymentMBeanUtils getDeploymentMBeanUtils() {
     return deploymentMBeanUtils;
@@ -223,6 +225,10 @@ public class SleeManagementMBeanUtils {
 
   public AlarmMBeanUtils getAlarmMBeanUtils() {
     return alarmMBeanUtils;
+  }
+
+  public ProfileMBeanUtils getProfileMBeanUtils() {
+		return profileMBeanUtils;
   }
 
   public static String doMessage(Throwable t) {

--- a/tools/slee-management-console/server/src/main/java/org/mobicents/slee/container/management/console/server/profiles/ProfileServiceImpl.java
+++ b/tools/slee-management-console/server/src/main/java/org/mobicents/slee/container/management/console/server/profiles/ProfileServiceImpl.java
@@ -1,0 +1,265 @@
+package org.mobicents.slee.container.management.console.server.profiles;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
+import javax.management.Attribute;
+import javax.management.ObjectName;
+import javax.slee.ComponentID;
+import javax.slee.management.ComponentDescriptor;
+import javax.slee.profile.ProfileID;
+import javax.slee.profile.ProfileSpecificationID;
+
+import org.mobicents.slee.container.management.console.client.ManagementConsoleException;
+import org.mobicents.slee.container.management.console.client.PropertiesInfo;
+import org.mobicents.slee.container.management.console.client.components.info.ComponentInfo;
+import org.mobicents.slee.container.management.console.client.profiles.ProfileService;
+import org.mobicents.slee.container.management.console.client.profiles.ProfileTableInfo;
+import org.mobicents.slee.container.management.console.server.Logger;
+import org.mobicents.slee.container.management.console.server.ManagementConsole;
+import org.mobicents.slee.container.management.console.server.components.ComponentInfoUtils;
+import org.mobicents.slee.container.management.console.server.mbeans.DeploymentMBeanUtils;
+import org.mobicents.slee.container.management.console.server.mbeans.ProfileMBeanUtils;
+import org.mobicents.slee.container.management.console.server.mbeans.ProfileProvisioningMBeanUtils;
+import org.mobicents.slee.container.management.console.server.mbeans.SleeMBeanConnection;
+
+import com.google.gwt.user.server.rpc.RemoteServiceServlet;
+
+public class ProfileServiceImpl extends RemoteServiceServlet implements ProfileService {
+
+	private ManagementConsole managementConsole = ManagementConsole.getInstance();
+
+	private SleeMBeanConnection sleeConnection = managementConsole.getSleeConnection();
+
+	private ProfileProvisioningMBeanUtils profileProvisioningMBean = sleeConnection.getSleeManagementMBeanUtils()
+			.getProfileProvisioningMBeanUtils();
+
+	private DeploymentMBeanUtils deploymentMBean = sleeConnection.getSleeManagementMBeanUtils()
+			.getDeploymentMBeanUtils();
+
+	private ProfileMBeanUtils profileMBean = sleeConnection.getSleeManagementMBeanUtils().getProfileMBeanUtils();
+
+	public static final String ARRAY_SEPARATOR = ",";
+
+	public static final String NAME_TYPE_SEPARATOR = " ::: ";
+
+	public void createProfileTable(String profileSpecId, String tableName) throws ManagementConsoleException {
+		ProfileSpecificationID profileSpecificationID = (ProfileSpecificationID) managementConsole.getComponentIDMap()
+				.get(profileSpecId);
+		profileProvisioningMBean.createProfileTable(profileSpecificationID, tableName);
+	}
+
+	public void createProfile(String tableName, String profileName) throws ManagementConsoleException {
+
+		ObjectName objectName = profileProvisioningMBean.createProfile(tableName, profileName);
+		profileMBean.commitProfile(objectName);
+	}
+
+	public void createProfile(String tableName, String profileName, PropertiesInfo propertiesInfo)
+			throws ManagementConsoleException {
+		ObjectName objectName = profileProvisioningMBean.createProfile(tableName, profileName);
+
+		String[] names = new String[propertiesInfo.size()];
+		String[] values = new String[propertiesInfo.size()];
+		String[] types = new String[propertiesInfo.size()];
+
+		Iterator<String> iterator = propertiesInfo.keySet().iterator();
+		int row = 0;
+		while (iterator.hasNext()) {
+			String name = iterator.next();
+			names[row] = name.split(NAME_TYPE_SEPARATOR)[0];
+			values[row] = propertiesInfo.getProperty(name);
+			types[row] = name.split(NAME_TYPE_SEPARATOR)[1];
+			if (values[row] == null || values[row].isEmpty()) {
+				profileMBean.setAttribute(objectName, new Attribute(names[row], null), types[row]);
+			} else {
+				profileMBean.setAttribute(objectName, new Attribute(names[row], values[row]), types[row]);
+			}
+			row++;
+		}
+		profileMBean.commitProfile(objectName);
+	}
+
+	public ProfileTableInfo[] getProfileTables() throws ManagementConsoleException {
+
+		Collection<String> profileTablesCollection = profileProvisioningMBean.getProfileTables();
+		ArrayList<String> tablesNames = new ArrayList<String>(profileTablesCollection);
+
+		ProfileSpecificationID[] profileSpecId = new ProfileSpecificationID[tablesNames.size()];
+
+		ArrayList<ProfileTableInfo> profileTableInfos = new ArrayList<ProfileTableInfo>();
+		for (int i = 0; i < tablesNames.size(); i++) {
+
+			profileSpecId[i] = profileProvisioningMBean.getProfileSpecification(tablesNames.get(i));
+
+			if (profileSpecId[i] == null) {
+				Logger.error("Profile-Table : " + tablesNames.get(i)
+						+ "  exists in h2database but it has no profile Specifications deployed .. ProfileSpecification need to be deployed or adminstratively remove it");
+			} else {
+
+				ProfileTableInfo profileTableInfo = new ProfileTableInfo(tablesNames.get(i), profileSpecId[i].getName(),
+						profileSpecId[i].getVendor(), profileSpecId[i].getVersion());
+				profileTableInfos.add(profileTableInfo);
+			}
+		}
+		return profileTableInfos.toArray(new ProfileTableInfo[profileTableInfos.size()]);
+	}
+
+	public String[] getProfileTables(String profileSpecificationId) throws ManagementConsoleException {
+		Collection<String> profileTablesCollection = profileProvisioningMBean
+				.getProfileTables(getProfileSpecificationIDFromString(profileSpecificationId));
+		return profileTablesCollection.toArray(new String[profileTablesCollection.size()]);
+
+	}
+
+	public String[] getProfiles(String tableName) throws ManagementConsoleException {
+		Collection<ProfileID> profilesCollection = profileProvisioningMBean.getProfiles(tableName);
+		ArrayList<ProfileID> profileIDsList = new ArrayList<ProfileID>(profilesCollection);
+
+		String[] profiles = new String[profileIDsList.size()];
+
+		for (int i = 0; i < profileIDsList.size(); i++) {
+			profiles[i] = profileIDsList.get(i).getProfileName();
+		}
+		return profiles;
+	}
+
+	public void removeProfile(String tableName, String profileName) throws ManagementConsoleException {
+		profileProvisioningMBean.removeProfile(tableName, profileName);
+	}
+
+	public void removeProfileTable(String tableName) throws ManagementConsoleException {
+		profileProvisioningMBean.removeProfileTable(tableName);
+	}
+
+	public void renameProfileTable(String currentTableName, String newTableName) throws ManagementConsoleException {
+		profileProvisioningMBean.renameProfileTable(currentTableName, newTableName);
+	}
+
+	public String[] getProfileSpecifications() throws ManagementConsoleException {
+
+		ComponentID[] componentIDs;
+		ComponentDescriptor[] componentDescriptors;
+		ComponentInfo[] componentInfos;
+
+		componentIDs = deploymentMBean.getProfileSpecifications();
+		componentDescriptors = deploymentMBean.getDescriptors(componentIDs);
+
+		componentInfos = new ComponentInfo[componentDescriptors.length];
+
+		String[] specificationsIds = new String[componentDescriptors.length];
+		for (int i = 0; i < componentDescriptors.length; i++) {
+			componentInfos[i] = ComponentInfoUtils.toComponentInfo(componentDescriptors[i]);
+
+			String id = new String("ProfileSpecificationID[name=" + componentInfos[i].getName() + ",vendor="
+					+ componentInfos[i].getVendor() + ",version=" + componentInfos[i].getVersion() + "]")
+							.replaceAll("\\s", "");
+			specificationsIds[i] = id;
+		}
+
+		return specificationsIds;
+	}
+
+	public void restoreProfile(String tableName, String profileName) throws ManagementConsoleException {
+		profileMBean.restoreProfile(profileProvisioningMBean.getProfile(tableName, profileName));
+	}
+
+	public String[] getAttributesValues(String tableName, String profileName, String[] attributesNames)
+			throws ManagementConsoleException {
+		String names[] = new String[attributesNames.length];
+		for (int i = 0; i < attributesNames.length; i++) {
+			names[i] = attributesNames[i].split(NAME_TYPE_SEPARATOR)[0];
+		}
+		if (profileName == null) {
+
+			String[] values = profileMBean.getAttributes(profileProvisioningMBean.getDefaultProfile(tableName), names);
+			return values;
+		} else {
+			ObjectName objectName = profileProvisioningMBean.getProfile(tableName, profileName);
+			return profileMBean.getAttributes(objectName, names);
+		}
+	}
+
+	public String[] getAttributesNames(String tableName, String profileName) throws ManagementConsoleException {
+		if (profileName == null) {
+			//getting default profile
+			return removeRedundancyAttributes(
+					profileMBean.getAllAttributes(profileProvisioningMBean.getDefaultProfile(tableName)));
+		} else {
+			return removeRedundancyAttributes(
+					profileMBean.getAllAttributes(profileProvisioningMBean.getProfile(tableName, profileName)));
+		}
+	}
+
+	private String[] removeRedundancyAttributes(String[] attributes) {
+		int newLength = attributes.length;
+		for (int i = 0; i < attributes.length; i++) {
+			if (attributes[i].contains("ProfileDirty") || attributes[i].contains("ProfileWriteable")) {
+				newLength--;
+			}
+		}
+		String[] result = new String[newLength];
+		int count = 0; 
+		for (int i = 0; i < attributes.length; i++)
+													
+		{
+			if (!attributes[i].contains("ProfileDirty") && !attributes[i].contains("ProfileWriteable")) {
+				result[count] = attributes[i];
+				count++;
+			}
+		}
+		return result;
+	}
+
+	private ProfileSpecificationID getProfileSpecificationIDFromString(String componentId) {
+		String componentString = componentId;
+		String componentType = componentString.substring(0, componentString.indexOf('['));
+		componentString = componentString.substring(componentType.length() + 1, componentString.length() - 1);
+		String[] componentStringParts = componentString.split(",");
+		String componentName = componentStringParts[0].substring("name=".length());
+		String componentVendor = componentStringParts[1].substring("vendor=".length());
+		String componentVersion = componentStringParts[2].substring("version=".length());
+		return new ProfileSpecificationID(componentName, componentVendor, componentVersion);
+	}
+
+	public PropertiesInfo getProfileAttributes(String tableName, String profileName) throws ManagementConsoleException {
+		String[] names = getAttributesNames(tableName, profileName);
+		String[] values = getAttributesValues(tableName, profileName, names);
+
+		PropertiesInfo propertiesInfo = new PropertiesInfo();
+
+		for (int i = 0; i < names.length; i++) {
+			propertiesInfo.setProperty(names[i], values[i]);
+		}
+		return propertiesInfo;
+	}
+
+	public void setProfileAttributes(String tableName, String profileName, PropertiesInfo propertiesInfo)
+			throws ManagementConsoleException {
+		profileMBean.editProfile(profileProvisioningMBean.getProfile(tableName, profileName));
+
+		String[] names = new String[propertiesInfo.size()];
+		String[] values = new String[propertiesInfo.size()];
+		String[] types = new String[propertiesInfo.size()];
+
+		Iterator<String> iterator = propertiesInfo.keySet().iterator();
+		int row = 0;
+		while (iterator.hasNext()) {
+			String name = iterator.next();
+			names[row] = name.split(NAME_TYPE_SEPARATOR)[0];
+			values[row] = propertiesInfo.getProperty(name);
+			types[row] = name.split(NAME_TYPE_SEPARATOR)[1];
+			if (values[row] == null || values[row].isEmpty()) {
+				profileMBean.setAttribute(profileProvisioningMBean.getProfile(tableName, profileName),
+						new Attribute(names[row], null), types[row]);
+			} else {
+				profileMBean.setAttribute(profileProvisioningMBean.getProfile(tableName, profileName),
+						new Attribute(names[row], values[row]), types[row]);
+			}
+			row++;
+		}
+		profileMBean.commitProfile(profileProvisioningMBean.getProfile(tableName, profileName));
+	}
+
+}

--- a/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/ServerConnection.java
+++ b/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/ServerConnection.java
@@ -32,6 +32,8 @@ import org.mobicents.slee.container.management.console.client.deployableunits.De
 import org.mobicents.slee.container.management.console.client.deployableunits.DeployableUnitsServiceAsync;
 import org.mobicents.slee.container.management.console.client.log.LogService;
 import org.mobicents.slee.container.management.console.client.log.LogServiceAsync;
+import org.mobicents.slee.container.management.console.client.profiles.ProfileService;
+import org.mobicents.slee.container.management.console.client.profiles.ProfileServiceAsync;
 import org.mobicents.slee.container.management.console.client.resources.ResourceService;
 import org.mobicents.slee.container.management.console.client.resources.ResourceServiceAsync;
 import org.mobicents.slee.container.management.console.client.sbb.entity.SbbEntitiesService;
@@ -76,6 +78,8 @@ public class ServerConnection {
   final static public AlarmsServiceAsync alarmsServiceAsync;
 
   final static public LogServiceAsync logServiceAsync;
+
+  final static public ProfileServiceAsync profileServiceAsync;
 
   static {
 
@@ -123,6 +127,10 @@ public class ServerConnection {
     ServiceDefTarget logEndpoint = (ServiceDefTarget) logServiceAsync;
     logEndpoint.setServiceEntryPoint(GWT.getModuleBaseURL().replaceAll("org.mobicents.slee.container.management.console.ManagementConsole", "") + "/LogService");
 
+  profileServiceAsync = (ProfileServiceAsync) GWT.create(ProfileService.class);
+		ServiceDefTarget profileEndpoint = (ServiceDefTarget) profileServiceAsync;
+		profileEndpoint.setServiceEntryPoint(GWT.getModuleBaseURL().replaceAll(
+				"org.mobicents.slee.container.management.console.ManagementConsole", "") + "/ProfileService");
   }
 
 }

--- a/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/common/UserInterface.java
+++ b/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/common/UserInterface.java
@@ -26,6 +26,7 @@ import org.mobicents.slee.container.management.console.client.pages.ActivityPage
 import org.mobicents.slee.container.management.console.client.pages.AlarmsPage;
 import org.mobicents.slee.container.management.console.client.pages.ComponentsPage;
 import org.mobicents.slee.container.management.console.client.pages.DeployableUnitsPage;
+import org.mobicents.slee.container.management.console.client.pages.ProfilesPage;
 import org.mobicents.slee.container.management.console.client.pages.ResourceAdaptorsPage;
 import org.mobicents.slee.container.management.console.client.pages.ServicesPage;
 import org.mobicents.slee.container.management.console.client.pages.SleePage;
@@ -67,7 +68,8 @@ public class UserInterface extends VerticalPanel implements HasHorizontalAlignme
 
     // smartTabPanel.add(LogManagementPage.getInfo());
     smartTabPanel.add(AlarmsPage.getInfo());
-    // smartTabPanel.add(ProfilesPage.getInfo());
+
+    smartTabPanel.add(ProfilesPage.getInfo());
 
     add(topPanel);
     add(smartTabPanel);

--- a/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/pages/ProfilesPage.java
+++ b/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/pages/ProfilesPage.java
@@ -22,23 +22,39 @@
 
 package org.mobicents.slee.container.management.console.client.pages;
 
+import org.mobicents.slee.container.management.console.client.common.CardControl;
 import org.mobicents.slee.container.management.console.client.common.SmartTabPage;
-
-import com.google.gwt.user.client.ui.Label;
+import org.mobicents.slee.container.management.console.client.profiles.ProfilesCard;
 
 public class ProfilesPage extends SmartTabPage {
 
-  public ProfilesPage() {
-    Label label = new Label("TODO");
+	private CardControl cardControl = new CardControl();
 
-    initWidget(label);
-  }
+	public ProfilesPage() {
+		initWidget(cardControl);
+	}
 
-  public static SmartTabPageInfo getInfo() {
-    return new SmartTabPageInfo("<image src='images/profiles.gif' /> Profiles", "Profiles") {
-      protected SmartTabPage createInstance() {
-        return new ProfilesPage();
-      }
-    };
-  }
+	public static SmartTabPageInfo getInfo() {
+		return new SmartTabPageInfo("<image src='images/profiles.gif' /> Profiles", "Profiles") {
+			protected SmartTabPage createInstance() {
+				return new ProfilesPage();
+			}
+		};
+	}
+
+	public void onInit() {
+		ProfilesCard profilesCard = new ProfilesCard();
+		cardControl.add(profilesCard, "<image align='absbottom' src='images/profiles.gif' /> Profile Tables", true);
+
+		cardControl.selectTab(0);
+		cardControl.setWidth("100%");
+	}
+
+	public void onHide() {
+		cardControl.onHide();
+	}
+
+	public void onShow() {
+		cardControl.onShow();
+	}
 }

--- a/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileAttributesListener.java
+++ b/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileAttributesListener.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2003-2011, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.mobicents.slee.container.management.console.client.profiles;
+
+import org.mobicents.slee.container.management.console.client.PropertiesInfo;
+
+/**
+ * @author Stefano Zappaterra
+ * 
+ */
+public interface ProfileAttributesListener {
+  public void onSaveProperties(PropertiesInfo propertiesInfo);
+
+public void onCancelProperties(PropertiesInfo propertiesInfo);
+}

--- a/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileAttributesPanel.java
+++ b/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileAttributesPanel.java
@@ -1,0 +1,241 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2003-2011, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.mobicents.slee.container.management.console.client.profiles;
+
+import java.util.Iterator;
+
+import org.mobicents.slee.container.management.console.client.Logger;
+import org.mobicents.slee.container.management.console.client.PropertiesInfo;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.HasText;
+import com.google.gwt.user.client.ui.HasVerticalAlignment;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.TextBoxBase;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * 
+ * @author Mohamed Salah
+ * @author <a href="mailto:msrashed100@gmail.com"> Mohamed Salah </a>
+ */
+public class ProfileAttributesPanel extends Composite {
+
+	private VerticalPanel rootPanel = new VerticalPanel();
+
+	private FlexTable propertiesTable = new FlexTable();
+
+	private FlexTable buttonPanel = new FlexTable();
+
+	private Button editButton = new Button("Edit");
+
+	private Button saveButton = new Button("Save & Commit");
+
+	private Button cancelButton = new Button("Cancel");
+
+	private String nameWidth = "100px";
+
+	final private int READ_MODE = 0;
+
+	final private int WRITE_MODE = 1;
+
+	private int mode = READ_MODE;
+
+	private PropertiesInfo propertiesInfo;
+
+	private ProfileAttributesListener listener;
+
+	public ProfileAttributesPanel(PropertiesInfo propertiesInfo, ProfileAttributesListener listener) {
+		super();
+
+		initWidget(rootPanel);
+
+		rootPanel.setWidth("100%");
+
+		propertiesTable.setStyleName("common-PropertiesPanel");
+		propertiesTable.setCellSpacing(0);
+		propertiesTable.setCellPadding(2);
+		setNameWidth("100px");
+
+		buttonPanel.setCellSpacing(0);
+		buttonPanel.setCellPadding(2);
+		
+		editButton.addClickHandler(new ClickHandler() {
+			public void onClick(ClickEvent event) {
+				onEditButton();
+			}
+		});
+		
+		
+		
+		buttonPanel.setWidget(0, 0, editButton);
+		buttonPanel.setWidget(0, 1, saveButton);
+		buttonPanel.setWidget(0, 2, cancelButton);
+
+		rootPanel.add(propertiesTable);
+		rootPanel.add(buttonPanel);
+
+		saveButton.addClickHandler(new ClickHandler() {
+			public void onClick(ClickEvent event) {
+				onSaveButton();
+			}
+		});
+
+		cancelButton.addClickHandler(new ClickHandler() {
+			public void onClick(ClickEvent event) {
+				onCancelButton();
+			}
+		});
+
+		this.propertiesInfo = propertiesInfo;
+		this.listener = listener;
+		refreshGUI();
+		
+	}
+
+	private void refreshGUI() {
+		Iterator<String> iterator = propertiesInfo.keySet().iterator();
+		int row = 0;
+		while (iterator.hasNext()) {
+			String name = (String) iterator.next();
+			String value = propertiesInfo.getProperty(name);
+			if (mode == READ_MODE) {
+				add(row, name, new Label(value));
+			} else {
+				TextBox textBox = new TextBox();
+				textBox.setTextAlignment(TextBoxBase.ALIGN_LEFT);
+				textBox.setText(value);
+				textBox.setWidth("100%");
+				
+				add(row, name, textBox);
+			}
+			row++;
+		}
+
+		if (mode == READ_MODE) {
+			editButton.setEnabled(true);
+			saveButton.setEnabled(false);
+			cancelButton.setEnabled(false);
+		} else {
+			editButton.setEnabled(false);
+			saveButton.setEnabled(true);
+			cancelButton.setEnabled(true);
+		}
+	}
+
+	private String getValue(int row) {
+		return ((HasText) propertiesTable.getWidget(row, 1)).getText();
+	}
+
+	private String getName(int row) {
+		return ((HasText) propertiesTable.getWidget(row, 0)).getText();
+	}
+
+	public void refreshPropertiesData() {
+		int size = propertiesInfo.size();
+
+		for (int row = 0; row < size; row++) {
+			String name = getName(row);
+			String value = getValue(row);
+			propertiesInfo.setProperty(name, value);
+		}
+	}
+
+	public void setMode(int mode) {
+		this.mode = mode;
+		refreshGUI();
+	}
+
+	private void setRowStyle(int row) {
+		propertiesTable.getCellFormatter().setStyleName(row, 0, "common-PropertiesPanel-name");
+		propertiesTable.getCellFormatter().setStyleName(row, 1, "common-PropertiesPanel-value");
+		propertiesTable.getRowFormatter().setVerticalAlign(row, HasVerticalAlignment.ALIGN_MIDDLE);
+
+		if (row != 0) {
+			propertiesTable.getCellFormatter().addStyleName(row, 0, "common-PropertiesPanel-notfirst");
+			propertiesTable.getCellFormatter().addStyleName(row, 1, "common-PropertiesPanel-notfirst");
+		}
+
+		if (row % 2 != 0) {
+			propertiesTable.getCellFormatter().addStyleName(row, 0, "common-PropertiesPanel-even");
+			propertiesTable.getCellFormatter().addStyleName(row, 1, "common-PropertiesPanel-even");
+		}
+
+		propertiesTable.getCellFormatter().setWidth(row, 0, nameWidth);
+		propertiesTable.getCellFormatter().setWidth(row, 1, "");
+	}
+
+	private void add(int row, String name, Widget value) {
+		if (value == null) {
+			add(row, name, new Label("-"));
+			return;
+		}
+		Label nameLabel = new Label(name);
+		nameLabel.setWordWrap(false);
+		propertiesTable.setWidget(row, 0, nameLabel);
+		propertiesTable.setWidget(row, 1, value);
+		setRowStyle(row);
+	}
+
+	public void setNameWidth(String nameWidth) {
+		this.nameWidth = nameWidth;
+	}
+
+	public void onEditButton() {
+		setMode(WRITE_MODE);
+	}
+
+	public void onSaveButton() {
+		refreshPropertiesData();
+
+		setMode(READ_MODE);
+
+		if (listener != null){
+			listener.onSaveProperties(propertiesInfo);
+		}
+	}
+
+	public void onCancelButton() {
+		setMode(READ_MODE);
+		if (listener != null)
+			listener.onCancelProperties(propertiesInfo);
+	}
+	public void onEditError(){
+		setMode(WRITE_MODE);
+	}
+
+	public void showCreationPanel() {
+		setMode(WRITE_MODE);
+		editButton.setVisible(false);
+	}
+	public void showEditPanel() {
+		editButton.setVisible(true);
+	}
+
+}

--- a/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileTablesListPanel.java
+++ b/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfileTablesListPanel.java
@@ -1,0 +1,301 @@
+package org.mobicents.slee.container.management.console.client.profiles;
+
+import org.mobicents.slee.container.management.console.client.Logger;
+import org.mobicents.slee.container.management.console.client.ServerCallback;
+import org.mobicents.slee.container.management.console.client.ServerConnection;
+import org.mobicents.slee.container.management.console.client.common.BrowseContainer;
+import org.mobicents.slee.container.management.console.client.common.ControlContainer;
+import org.mobicents.slee.container.management.console.client.common.ListPanel;
+import org.mobicents.slee.container.management.console.client.common.Title;
+
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HasHorizontalAlignment;
+import com.google.gwt.user.client.ui.Hyperlink;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.TextBox;
+
+public class ProfileTablesListPanel extends Composite {
+
+	private BrowseContainer browseContainer;
+
+	private ProfileServiceAsync service = ServerConnection.profileServiceAsync;
+
+	private ControlContainer rootPanel = new ControlContainer();
+
+	private ListPanel profileTablesListPanel = new ListPanel();
+
+	private String[] tables;
+	
+	private static final int COLUMN_TABLE_NAME = 0;
+	private static final int COLUMN_ACTION = 1;
+	private static final int COLUMN_EMPTY = 2;
+
+	private static final int ROW_PROFILE_SPECIFICATIONS_LIST = 0;
+	private static final int ROW_TABLE_COUNT = 1;
+	private static final int ROW_PROFILE_LIST_PANNEL = 2;
+	private static final int ROW_PROFILE_TABLE_CREATION_TITLE = 3;
+	private static final int ROW_PROFILE_TABLE_CREATION_PANEL = 4;
+
+	private Label tableCount;
+
+	private final TextBox tableNameTextBox = new TextBox();
+	private final ListBox TypeListBox = new ListBox();
+
+	public ProfileTablesListPanel(BrowseContainer browseContainer) {
+		super();
+
+		this.browseContainer = browseContainer;
+		initWidget(rootPanel);
+
+		rootPanel.getCellFormatter().setHorizontalAlignment(1, 0, HasHorizontalAlignment.ALIGN_RIGHT);
+		
+		addProfileSpecificationsListPannel();
+		addRefreshPanel();
+		addProfileListPanel();
+		addProfileTableCreationPanel();
+	}
+
+	
+	private void addProfileListPanel() {
+		profileTablesListPanel.setHeader(COLUMN_TABLE_NAME, "Table Name");
+		profileTablesListPanel.setHeader(COLUMN_ACTION, "Action");
+		profileTablesListPanel.setHeader(COLUMN_EMPTY, "");
+		profileTablesListPanel.setColumnWidth(COLUMN_TABLE_NAME, "100%");
+		rootPanel.setWidget(ROW_PROFILE_LIST_PANNEL, 0, profileTablesListPanel);
+	}
+
+	private void addRefreshPanel() {
+		Hyperlink refreshLink = new Hyperlink("refresh", "refresh");
+		refreshLink.setStyleName("common-pointer-curser");
+		refreshLink.addClickHandler(new ClickHandler() {
+			
+			public void onClick(ClickEvent arg0) {
+				if(TypeListBox.getSelectedIndex() != 0){
+					getTables(TypeListBox.getValue(TypeListBox.getSelectedIndex()));		
+				}
+			}
+		});
+		ControlContainer counterTypeTitlePanel = new ControlContainer();
+		tableCount = new Label("");
+		counterTypeTitlePanel.setWidget(0, 0, tableCount);
+		counterTypeTitlePanel.setWidget(0, 1, new Image("images/refresh.gif"));
+		counterTypeTitlePanel.setWidget(0, 2, refreshLink);
+		counterTypeTitlePanel.getCellFormatter().setWidth(0, 0, "100%");
+		rootPanel.setWidget(ROW_TABLE_COUNT, 0, counterTypeTitlePanel);
+	}
+
+	private void addProfileSpecificationsListPannel() {
+
+		ControlContainer typeListPannel = new ControlContainer();
+		typeListPannel.setWidth("");
+		typeListPannel.setWidget(0, 0, new Label("Profile Specifications:"));
+		typeListPannel.setWidget(0, 1, TypeListBox);
+		TypeListBox.addItem("");
+		TypeListBox.setWidth("100%");
+		TypeListBox.setHeight("200%");
+		TypeListBox.addChangeHandler(new ChangeHandler() {
+			public void onChange(ChangeEvent arg0) {
+				int selectedIndex = TypeListBox.getSelectedIndex();
+				if(selectedIndex != 0 ){
+					String profileSpecId = TypeListBox.getValue(selectedIndex);
+					getTables(profileSpecId);
+				}
+			}
+		});
+		TypeListBox.setVisibleItemCount(1);
+		rootPanel.setWidget(ROW_PROFILE_SPECIFICATIONS_LIST, 0, typeListPannel);
+
+		ServerCallback callback = new ServerCallback(this) {
+			@Override
+			public void onSuccess(Object result) {
+				String[] profileSpecificationIDs = (String[]) result;
+				for (String type : profileSpecificationIDs) {
+					TypeListBox.addItem(convertProfileSpecFormat(type),type);
+				}
+				TypeListBox.setSelectedIndex(0);
+			}
+
+			@Override
+			public void onFailure(Throwable caught) {
+				TypeListBox.clear();
+				super.onFailure(caught);
+			}
+
+		};
+
+		service.getProfileSpecifications(callback);
+		
+		
+		
+	}
+	private void addProfileTableCreationPanel() {
+		ControlContainer createProfileTablePanel = new ControlContainer();
+		createProfileTablePanel.setWidth("");
+		Button createProfileTableButton = new Button("Create");
+
+		// createEntityPanel.setWidget(0, 0, new
+		// Image("images/resources.createentity.gif"));
+		createProfileTablePanel.setWidget(0, 0, new Label("Table Name:"));
+		createProfileTablePanel.setWidget(0, 1, tableNameTextBox);
+
+		createProfileTablePanel.setWidget(1, 0, createProfileTableButton);
+		createProfileTableButton.addClickHandler(new ClickHandler() {
+
+			public void onClick(ClickEvent arg0) {
+				int index = TypeListBox.getSelectedIndex();
+				onCreateProfileTableClicked(tableNameTextBox.getText(), TypeListBox.getValue(index).toString());
+			}
+		});
+
+		tableNameTextBox.addKeyDownHandler(new KeyDownHandler() {
+
+			public void onKeyDown(KeyDownEvent event) {
+				if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
+					int index = TypeListBox.getSelectedIndex();
+					onCreateProfileTableClicked(tableNameTextBox.getText(), TypeListBox.getValue(index).toString());
+				}
+			}
+		});
+		rootPanel.setWidget(ROW_PROFILE_TABLE_CREATION_TITLE, 0,
+				new Title("Create Profile Table", Title.TITLE_LEVEL_1));
+		rootPanel.setWidget(ROW_PROFILE_TABLE_CREATION_PANEL, 0, createProfileTablePanel);
+	}
+	private void getTables(String profileSpecId) {
+		ServerCallback callback = new ServerCallback(this) {
+			public void onSuccess(Object result) {
+				tables = (String[]) result;
+				refreshTable();
+				tableNameTextBox.setText("");
+			}
+
+			@Override
+			public void onFailure(Throwable caught) {
+				tables = null;
+				refreshTable();
+				super.onFailure(caught);
+			}
+
+		};
+		service.getProfileTables(profileSpecId, callback);
+	}
+	private void refreshTable() {
+		if (tables == null || tables.length == 0) {
+			profileTablesListPanel.emptyTable();
+			tableCount.setText("There are no profile tables");
+			browseContainer.setTitle(this, "There are no profile tables");
+			return;
+		}
+
+		tableCount.setText("Total: " + tables.length);
+
+		browseContainer.setTitle(this, "Tables");
+
+		profileTablesListPanel.emptyTable();
+		for (int i = 0; i < tables.length; i++) {
+
+			final String tableName = tables[i];
+
+			Hyperlink profileTableLink = new Hyperlink(tableName, tableName);
+			profileTableLink.setStyleName("common-pointer-curser");
+			profileTableLink.addClickHandler(new ClickHandler() {
+
+				public void onClick(ClickEvent arg0) {
+					onProfileTableClicked(tableName);
+				}
+			});
+
+			profileTablesListPanel.setCell(i, COLUMN_TABLE_NAME, profileTableLink);
+
+			Hyperlink removeLink = new Hyperlink("remove", "remove table " + tableName);
+			removeLink.addClickHandler(new ClickHandler() {
+				public void onClick(ClickEvent arg0) {
+					onRemove(tableName);
+				}
+			});
+			
+			Hyperlink renameLink = new Hyperlink("rename", "rename table " + tableName);
+			renameLink.addClickHandler(new ClickHandler() {
+				public void onClick(ClickEvent arg0) {
+					onRename(tableName);
+				}
+			});
+
+			profileTablesListPanel.setCell(i, COLUMN_ACTION, removeLink);
+			profileTablesListPanel.setCell(i, COLUMN_EMPTY, renameLink);
+			
+			
+		}
+	}
+
+	private void onCreateProfileTableClicked(final String name, final String type) {
+		if ((name != null) && (type != null)) {
+			ServerCallback callback = new ServerCallback(this) {
+				public void onSuccess(Object result) {
+					Logger.info("Profile Table: " + name + " created");
+					if(TypeListBox.getSelectedIndex() != 0){
+						getTables(TypeListBox.getValue(TypeListBox.getSelectedIndex()));		
+					}
+				}
+
+				@Override
+				public void onFailure(Throwable caught) {
+					if(TypeListBox.getSelectedIndex() != 0){
+						getTables(TypeListBox.getValue(TypeListBox.getSelectedIndex()));		
+					}
+					super.onFailure(caught);
+				}
+			};
+			service.createProfileTable(type, name, callback);
+		}
+
+	}
+
+	private void onProfileTableClicked(String tableName) {
+//		browseContainer.empty();
+		ProfilesListPanel profileTablesListPanel = new ProfilesListPanel(browseContainer, tableName);
+		browseContainer.add(tableName, profileTablesListPanel);
+	}
+
+	private void onRemove(final String tableName) {
+		ServerCallback callback = new ServerCallback(this) {
+			public void onSuccess(Object result) {
+				Logger.info(tableName + " removed");
+				if(TypeListBox.getSelectedIndex() != 0){
+					getTables(TypeListBox.getValue(TypeListBox.getSelectedIndex()));		
+				}
+			}
+
+			@Override
+			public void onFailure(Throwable caught) {
+				if(TypeListBox.getSelectedIndex() != 0){
+					getTables(TypeListBox.getValue(TypeListBox.getSelectedIndex()));		
+				}
+				super.onFailure(caught);
+			}
+		};
+		service.removeProfileTable(tableName, callback);
+	}
+	private void onRename(final String tableName) {
+		//TODO
+	}
+	private String convertProfileSpecFormat(String profileSpec){
+		String componentString = profileSpec;
+		String componentType = componentString.substring(0, componentString.indexOf('['));
+		componentString = componentString.substring(componentType.length() + 1, componentString.length() - 1);
+		String[] componentStringParts = componentString.split(",");
+		String componentName = componentStringParts[0].substring("name=".length());
+		String componentVendor = componentStringParts[1].substring("vendor=".length());
+		String componentVersion = componentStringParts[2].substring("version=".length());
+		return componentName+" / "+componentVendor+" / "+componentVersion;
+	}
+}

--- a/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfilesCard.java
+++ b/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfilesCard.java
@@ -1,0 +1,33 @@
+package org.mobicents.slee.container.management.console.client.profiles;
+
+import org.mobicents.slee.container.management.console.client.common.BrowseContainer;
+import org.mobicents.slee.container.management.console.client.common.Card;
+
+public class ProfilesCard extends Card{
+	private BrowseContainer browseContainer = new BrowseContainer();
+	
+	
+	public ProfilesCard() {
+		super();
+	    initWidget(browseContainer);
+	}
+
+	@Override
+	public void onShow() {
+		browseContainer.empty();
+	    ProfileTablesListPanel profileTablesListPanel = new ProfileTablesListPanel(browseContainer);
+	    browseContainer.add("Tables", profileTablesListPanel);		
+	}
+
+	@Override
+	public void onHide() {
+				
+	}
+
+	@Override
+	public void onInit() {
+		// TODO Auto-generated method stub
+		
+	}
+
+}

--- a/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfilesListPanel.java
+++ b/tools/slee-management-console/war/src/main/java/org/mobicents/slee/container/management/console/client/profiles/ProfilesListPanel.java
@@ -1,0 +1,386 @@
+package org.mobicents.slee.container.management.console.client.profiles;
+
+import org.mobicents.slee.container.management.console.client.Logger;
+import org.mobicents.slee.container.management.console.client.PropertiesInfo;
+import org.mobicents.slee.container.management.console.client.ServerCallback;
+import org.mobicents.slee.container.management.console.client.ServerConnection;
+import org.mobicents.slee.container.management.console.client.common.BrowseContainer;
+import org.mobicents.slee.container.management.console.client.common.ControlContainer;
+
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HasHorizontalAlignment;
+import com.google.gwt.user.client.ui.Hyperlink;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.TextBox;
+
+public class ProfilesListPanel extends Composite implements ProfileAttributesListener {
+
+	private BrowseContainer browseContainer;
+
+	private ProfileServiceAsync service = ServerConnection.profileServiceAsync;
+
+	private ControlContainer rootPanel = new ControlContainer();
+
+	private ListBox profilesListBox;
+
+	ProfileAttributesPanel profilePropertiesPanel;
+
+	private PropertiesInfo profileProperties;
+
+
+	private static final int ROW_PROFILES_REFRESH = 0;
+	private static final int ROW_PROFILE_LIST_PANNEL = 1;
+	private static final int ROW_PROFILE_MANAGEMENT_PANNEL = 2;
+	private static final int ROW_SEPERATOR = 3;
+	private static final int ROW_PROFILE_NAME_PANNEL = 4;
+	private static final int ROW_PROFILE_DATA_PANNEL = 5;
+
+	private Label profileCount;
+
+	private final TextBox profileNameTextBox = new TextBox();
+
+	private final Button createProfileButton = new Button("Create");
+	private final Button removeProfileButton = new Button("Remove");
+	private final Button restoreProfileButton = new Button("Restore");
+
+	private String tableName;
+	private ControlContainer profileManagementPanel;
+	private ControlContainer profileNamePannel;
+
+	private boolean creation = false;
+
+
+	public ProfilesListPanel(BrowseContainer browseContainer, String tableName) {
+		super();
+
+		this.tableName = tableName;
+		this.browseContainer = browseContainer;
+		initWidget(rootPanel);
+
+		Hyperlink refreshLink = new Hyperlink("refresh", "refresh");
+		refreshLink.setStyleName("common-pointer-curser");
+		refreshLink.addClickHandler(new ClickHandler() {
+			public void onClick(ClickEvent arg0) {
+				addProfileList();
+				try {
+
+					if (rootPanel.isCellPresent(ROW_PROFILE_DATA_PANNEL, 0)) {
+						rootPanel.clearCell(ROW_PROFILE_DATA_PANNEL, 0);
+					}
+					if (rootPanel.isCellPresent(ROW_PROFILE_NAME_PANNEL, 0)) {
+						rootPanel.clearCell(ROW_PROFILE_NAME_PANNEL, 0);
+					}
+					profilesListBox.setEnabled(true);
+					createProfileButton.setEnabled(true);
+					removeProfileButton.setEnabled(true);
+					restoreProfileButton.setEnabled(true);
+					creation = false;
+				} catch (Exception e) {
+					Logger.error(e.getMessage());
+				}
+			}
+		});
+
+		ControlContainer counterTypeTitlePanel = new ControlContainer();
+		profileCount = new Label("Profiles(0)");
+		counterTypeTitlePanel.setWidget(0, 0, profileCount);
+		counterTypeTitlePanel.setWidget(0, 1, new Image("images/refresh.gif"));
+		counterTypeTitlePanel.setWidget(0, 2, refreshLink);
+		counterTypeTitlePanel.getCellFormatter().setWidth(0, 0, "100%");
+		rootPanel.setWidget(ROW_PROFILES_REFRESH, 0, counterTypeTitlePanel);
+
+		rootPanel.getCellFormatter().setHorizontalAlignment(1, 0, HasHorizontalAlignment.ALIGN_RIGHT);
+
+		addProfileList();
+		addProfileManagementPanel();
+		addSeperatorPanel(ROW_SEPERATOR);
+		addProfileNamePanel();
+
+	}
+
+	private void addSeperatorPanel(int row) {
+		ControlContainer seperatorPannel = new ControlContainer();
+		seperatorPannel.setHeight("15px");
+		rootPanel.setWidget(row, 0, seperatorPannel);
+	}
+
+	private void addProfileNamePanel() {
+		profileNamePannel = new ControlContainer();
+		profileNamePannel.setText(0, 0, "Profile Name");
+		profileNamePannel.setWidget(1, 0, profileNameTextBox);
+	}
+
+	private void showProfile() {
+		int selectedIndex = profilesListBox.getSelectedIndex();
+
+		String profileName = profilesListBox.getValue(selectedIndex);
+		getProfileAttributes(profileName);
+	}
+
+	private void addProfileList() {
+
+		profilesListBox = new ListBox();
+		profilesListBox.setFocus(true);
+		ControlContainer profileListpannel = new ControlContainer();
+		profileListpannel.setWidget(0, 0, profilesListBox);
+
+		profilesListBox.setWidth("100%");
+		profilesListBox.setVisibleItemCount(5);
+		profilesListBox.addClickHandler(new ClickHandler() {
+
+			public void onClick(ClickEvent var1) {
+				showProfile();
+			}
+		});
+
+		profilesListBox.addChangeHandler(new ChangeHandler() {
+			public void onChange(ChangeEvent arg0) {
+				showProfile();
+			}
+		});
+
+		rootPanel.setWidget(ROW_PROFILE_LIST_PANNEL, 0, profileListpannel);
+
+		ServerCallback callback = new ServerCallback(this) {
+			@Override
+			public void onSuccess(Object result) {
+				String[] profiles = (String[]) result;
+				for (String profile : profiles) {
+					profilesListBox.addItem(profile);
+				}
+				profileCount.setText("Profiles(" + profiles.length + ")");
+			}
+
+			@Override
+			public void onFailure(Throwable caught) {
+				profilesListBox.clear();
+				super.onFailure(caught);
+			}
+
+		};
+
+		service.getProfiles(tableName, callback);
+	}
+
+	private void getProfileAttributes(final String profileName) {
+		ServerCallback callback = new ServerCallback(this) {
+			public void onSuccess(Object result) {
+				profileProperties = (PropertiesInfo) result;
+				loadProfileProperties();
+			}
+
+			@Override
+			public void onFailure(Throwable caught) {
+				profileProperties = null;
+				addProfileList();
+				super.onFailure(caught);
+			}
+		};
+		service.getProfileAttributes(tableName, profileName, callback);
+	}
+
+	private void addProfileManagementPanel() {
+
+		profileManagementPanel = new ControlContainer();
+		profileManagementPanel.setWidth("");
+
+		createProfileButton.setStyleName("common-pointer-curser");
+		removeProfileButton.setStyleName("common-pointer-curser");
+		restoreProfileButton.setStyleName("common-pointer-curser");
+		profileManagementPanel.setWidget(0, 1, createProfileButton);
+		profileManagementPanel.setWidget(0, 2, removeProfileButton);
+		profileManagementPanel.setWidget(0, 3, restoreProfileButton);
+
+		createProfileButton.addClickHandler(new ClickHandler() {
+			public void onClick(ClickEvent arg0) {
+				onCreateProfileBtnClicked();
+			}
+		});
+
+		removeProfileButton.addClickHandler(new ClickHandler() {
+			public void onClick(ClickEvent arg0) {
+				onRemoveProfileBtnClicked();
+			}
+		});
+		restoreProfileButton.addClickHandler(new ClickHandler() {
+			public void onClick(ClickEvent arg0) {
+				onRestoreProfileBtnClicked();
+			}
+
+		});
+		rootPanel.setWidget(ROW_PROFILE_MANAGEMENT_PANNEL, 0, profileManagementPanel);
+	}
+
+	private void onRestoreProfileBtnClicked() {
+		final String profileName = profilesListBox.getItemText(profilesListBox.getSelectedIndex());
+		ServerCallback callback = new ServerCallback(this) {
+			@Override
+			public void onSuccess(Object result) {
+				showProfile();
+			}
+
+			@Override
+			public void onFailure(Throwable caught) {
+				Logger.error("failed to restore profile as it remains unchanged.");
+			}
+
+		};
+
+		service.restoreProfile(tableName, profileName, callback);
+	}
+
+	private void onCreateProfileBtnClicked() {
+		this.creation = true;
+		rootPanel.setWidget(ROW_PROFILE_NAME_PANNEL, 0, profileNamePannel);
+		profilesListBox.setEnabled(false);
+		createProfileButton.setEnabled(false);
+		removeProfileButton.setEnabled(false);
+		restoreProfileButton.setEnabled(false);
+		addCreateProfilePanel();
+	}
+
+	private void onRemoveProfileBtnClicked() {
+		if (profilesListBox.getSelectedIndex() >= 0) {
+			final String profileName = profilesListBox.getItemText(profilesListBox.getSelectedIndex());
+			ServerCallback callback = new ServerCallback(this) {
+				public void onSuccess(Object result) {
+					Logger.info(profileName + " removed");
+					addProfileList();
+					try {
+						if (rootPanel.isCellPresent(ROW_PROFILE_DATA_PANNEL, 0)) {
+							rootPanel.clearCell(ROW_PROFILE_DATA_PANNEL, 0);
+						}
+						if (rootPanel.isCellPresent(ROW_PROFILE_NAME_PANNEL, 0)) {
+							rootPanel.clearCell(ROW_PROFILE_NAME_PANNEL, 0);
+						}
+
+					} catch (Exception e) {
+						Logger.error(e.getMessage());
+					}
+
+				}
+
+				@Override
+				public void onFailure(Throwable caught) {
+
+					addProfileList();
+					super.onFailure(caught);
+				}
+			};
+			service.removeProfile(tableName, profileName, callback);
+		}
+
+	}
+
+	private void addCreateProfilePanel() {
+		getProfileAttributes(null);
+	}
+
+	private void loadProfileProperties() {
+		try {
+			profilePropertiesPanel = new ProfileAttributesPanel(profileProperties, this);
+			if (creation) {
+				profilePropertiesPanel.showCreationPanel();
+			} else {
+				profilePropertiesPanel.showEditPanel();
+			}
+			rootPanel.setWidget(ROW_PROFILE_DATA_PANNEL, 0, profilePropertiesPanel);
+		} catch (Exception e) {
+			Logger.error(e.getMessage());
+		}
+	}
+
+	public void onSaveProperties(PropertiesInfo propertiesInfo) {
+		try {
+			this.profileProperties = propertiesInfo;
+			setAttributes();
+		} catch (Exception e) {
+			Logger.error(e.getMessage());
+		}
+	}
+
+	private void setAttributes() {
+
+		ServerCallback callback = new ServerCallback(this) {
+			public void onSuccess(Object result) {
+				if (creation) {
+					creation = false;
+					createProfileButton.setEnabled(true);
+					removeProfileButton.setEnabled(true);
+					restoreProfileButton.setEnabled(true);
+
+					if (rootPanel.isCellPresent(ROW_PROFILE_NAME_PANNEL, 0)) {
+						rootPanel.clearCell(ROW_PROFILE_NAME_PANNEL, 0);
+					}
+					Logger.info(profileNameTextBox.getText() + " is created Successfuly...");
+					addProfileList();
+					profileNameTextBox.setText("");
+
+				} else {
+
+					Logger.info(profilesListBox.getItemText(profilesListBox.getSelectedIndex())
+							+ " data is set Successfuly...");
+				}
+
+				if (rootPanel.isCellPresent(ROW_PROFILE_DATA_PANNEL, 0)) {
+					rootPanel.clearCell(ROW_PROFILE_DATA_PANNEL, 0);
+				}
+
+				showProfile();
+
+			}
+
+			@Override
+			public void onFailure(Throwable caught) {
+
+				if (creation) {
+					Logger.info("faild to create profile : " + profileNameTextBox.getText() + " \n");
+				} else {
+					Logger.info("faild to set " + profilesListBox.getItemText(profilesListBox.getSelectedIndex())
+							+ " data\n");
+				}
+
+				profilePropertiesPanel.onEditError();
+				super.onFailure(caught);
+			}
+
+		};
+		if (creation) {
+			if (profileNameTextBox.getText().isEmpty() || profileNameTextBox.getText() == null) {
+				Logger.error("empty Profile Name ");
+				profilePropertiesPanel.onEditError();
+			} else {
+				service.createProfile(tableName, profileNameTextBox.getText(), profileProperties, callback);
+			}
+
+		} else {
+			service.setProfileAttributes(tableName, profilesListBox.getItemText(profilesListBox.getSelectedIndex()),
+					profileProperties, callback);
+		}
+
+	}
+
+	public void onCancelProperties(PropertiesInfo propertiesInfo) {
+		if (rootPanel.isCellPresent(ROW_PROFILE_DATA_PANNEL, 0)) {
+			rootPanel.clearCell(ROW_PROFILE_DATA_PANNEL, 0);
+		}
+		if (rootPanel.isCellPresent(ROW_PROFILE_NAME_PANNEL, 0)) {
+			rootPanel.clearCell(ROW_PROFILE_NAME_PANNEL, 0);
+		}
+		profilesListBox.setEnabled(true);
+		createProfileButton.setEnabled(true);
+		removeProfileButton.setEnabled(true);
+		restoreProfileButton.setEnabled(true);
+		creation = false;
+		showProfile();
+
+	}
+
+}

--- a/tools/slee-management-console/war/src/main/webapp/WEB-INF/web.xml
+++ b/tools/slee-management-console/war/src/main/webapp/WEB-INF/web.xml
@@ -82,7 +82,12 @@
 			org.mobicents.slee.container.management.console.server.sbb.entities.SbbEntitiesServiceImpl
 		</servlet-class>
 	</servlet>
-	
+	<servlet>
+		<servlet-name>ProfileService</servlet-name>
+		<servlet-class>
+			org.mobicents.slee.container.management.console.server.profiles.ProfileServiceImpl
+		</servlet-class>
+	</servlet>
 	<servlet-mapping>
 		<servlet-name>ComponentsService</servlet-name>
 		<url-pattern>/ComponentsService</url-pattern>
@@ -132,10 +137,13 @@
 		<url-pattern>/LogService</url-pattern>
 	</servlet-mapping>
 	<servlet-mapping>
-    <servlet-name>AlarmsService</servlet-name>
-    <url-pattern>/AlarmsService</url-pattern>
-  </servlet-mapping>
-	
+	    <servlet-name>AlarmsService</servlet-name>
+	   	 <url-pattern>/AlarmsService</url-pattern>
+	  </servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>ProfileService</servlet-name>
+		<url-pattern>/ProfileService</url-pattern>
+	</servlet-mapping>
 	<welcome-file-list>
 		<welcome-file>index.html</welcome-file>
 	</welcome-file-list>


### PR DESCRIPTION
implementing profile management page with the following features:
 - get all deployed ProfileSpecifications as list
 - create and remove profile table from selected ProfileSpecificationID
 - create , update, restore and remove profiles from chosen Profile-Table
screenshoots:
[profile-management-page-screenshoots.pdf](https://github.com/RestComm/jain-slee/files/2825542/profile-management-page-screenshoots.pdf)



