### PR TITLE
Fix confusing logging mistake

### DIFF
--- a/container/router/src/main/java/org/mobicents/slee/runtime/eventrouter/routingtask/EventRoutingTaskImpl.java
+++ b/container/router/src/main/java/org/mobicents/slee/runtime/eventrouter/routingtask/EventRoutingTaskImpl.java
@@ -430,8 +430,7 @@ public class EventRoutingTaskImpl implements EventRoutingTask {
 									// it's a root sbb
 									if (!sbbEntity.isRemoved() && sbbEntity.getAttachmentCount() == 0) {
 										if (debugLogging) {
-											logger
-											.debug("Removing sbb entity "+sbbEntity.getSbbEntityId()+" , the attachment count is not 0");
+											logger.debug("Removing sbb entity " + sbbEntity.getSbbEntityId() + ", the attachment count is 0");
 										}
 										// If it's the same entity then this is an
 										// "Op and


### PR DESCRIPTION
The logging statement is confusing when analysing event routing as it reports non-zero attachment count when it is in fact zero. It was probably miscopied from equivalent log record in the branch above.